### PR TITLE
Reject non-empty content after table headers

### DIFF
--- a/src/Parser/Parser.php
+++ b/src/Parser/Parser.php
@@ -92,6 +92,9 @@ final class Parser
             if ($token->is(TokenType::LeftBracket)) {
                 $table = $this->parseTableHeader();
                 if ($table !== null) {
+                    // Check that table header is followed by newline, EOF, comment, or whitespace leading to those
+                    $this->checkKeyValueTerminator();
+
                     if ($this->preserveTrivia) {
                         $table->setLeadingTrivia($leadingTrivia);
                         $table->setTrailingTrivia($this->collectTrailingTrivia());


### PR DESCRIPTION
## Summary
- reject extra non-comment content after table headers such as `[table] key = "value"`
- reuse the existing terminator check after parsing table headers
- tighten parser behavior to match TOML expectations on current master

## Verification
- vendor/bin/phpunit /tmp/toml-pr-check-1984691/tests/TomlTest.php /tmp/toml-pr-check-1984691/tests/Conformance/SupportedSyntaxTest.php
