### PR TITLE
feat: add encodeFile() and encodeDocumentFile() convenience methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,8 +90,11 @@ use PhpCollective\Toml\Encoder\EncoderOptions;
 use PhpCollective\Toml\Ast\Value\StringStyle;
 use PhpCollective\Toml\Ast\Value\StringValue;
 
-// Encode to TOML
+// Encode to TOML string
 $toml = Toml::encode($array);
+
+// Encode directly to file
+Toml::encodeFile('/path/to/config.toml', $array);
 
 // With options - e.g. omit nulls instead of throwing
 $toml = Toml::encode($array, new EncoderOptions(skipNulls: true));
@@ -99,6 +102,9 @@ $toml = Toml::encode($array, new EncoderOptions(skipNulls: true));
 // encodeDocument() is normalized by default
 $document = Toml::parse($tomlString, true);
 $toml = Toml::encodeDocument($document);
+
+// Encode document directly to file
+Toml::encodeDocumentFile('/path/to/output.toml', $document);
 
 // Opt into source-aware formatting for minimal-diff AST re-encoding
 $document = Toml::parse($tomlString, true);

--- a/src/Toml.php
+++ b/src/Toml.php
@@ -7,6 +7,7 @@ namespace PhpCollective\Toml;
 use PhpCollective\Toml\Ast\Document;
 use PhpCollective\Toml\Encoder\Encoder;
 use PhpCollective\Toml\Encoder\EncoderOptions;
+use PhpCollective\Toml\Exception\EncodeException;
 use PhpCollective\Toml\Exception\ParseException;
 use PhpCollective\Toml\Parser\Parser;
 use PhpCollective\Toml\Parser\ParseResult;
@@ -102,5 +103,37 @@ final class Toml
         $encoder = new Encoder($options ?? new EncoderOptions());
 
         return $encoder->encodeDocument($doc);
+    }
+
+    /**
+     * Encode PHP array to TOML and write to file.
+     *
+     * @param string $path
+     * @param array<string, mixed> $data
+     * @param \PhpCollective\Toml\Encoder\EncoderOptions|null $options
+     *
+     * @throws \PhpCollective\Toml\Exception\EncodeException on encoding or write failure
+     */
+    public static function encodeFile(string $path, array $data, ?EncoderOptions $options = null): void
+    {
+        $toml = self::encode($data, $options);
+
+        if (@file_put_contents($path, $toml) === false) {
+            throw new EncodeException("Cannot write file: {$path}");
+        }
+    }
+
+    /**
+     * Encode AST document to TOML and write to file.
+     *
+     * @throws \PhpCollective\Toml\Exception\EncodeException on encoding or write failure
+     */
+    public static function encodeDocumentFile(string $path, Document $doc, ?EncoderOptions $options = null): void
+    {
+        $toml = self::encodeDocument($doc, $options);
+
+        if (@file_put_contents($path, $toml) === false) {
+            throw new EncodeException("Cannot write file: {$path}");
+        }
     }
 }

--- a/tests/TomlTest.php
+++ b/tests/TomlTest.php
@@ -7,6 +7,7 @@ namespace PhpCollective\Toml\Test;
 use PhpCollective\Toml\Ast\Document;
 use PhpCollective\Toml\Encoder\DocumentFormattingMode;
 use PhpCollective\Toml\Encoder\EncoderOptions;
+use PhpCollective\Toml\Exception\EncodeException;
 use PhpCollective\Toml\Exception\ParseException;
 use PhpCollective\Toml\Toml;
 use PhpCollective\Toml\Value\LocalDate;
@@ -228,5 +229,77 @@ TOML);
         $this->assertSame('2024-03-15', $decoded['date']);
         $this->assertSame('10:30:45', $decoded['time']);
         $this->assertSame('2024-03-15 10:30:45', $decoded['timestamp']);
+    }
+
+    public function testEncodeFile(): void
+    {
+        $path = sys_get_temp_dir() . '/toml_test_' . uniqid() . '.toml';
+
+        try {
+            Toml::encodeFile($path, ['name' => 'test', 'count' => 42]);
+
+            $this->assertFileExists($path);
+            $content = file_get_contents($path);
+            $this->assertIsString($content);
+            $this->assertStringContainsString('name = "test"', $content);
+            $this->assertStringContainsString('count = 42', $content);
+
+            // Verify round-trip
+            $decoded = Toml::decodeFile($path);
+            $this->assertSame(['name' => 'test', 'count' => 42], $decoded);
+        } finally {
+            @unlink($path);
+        }
+    }
+
+    public function testEncodeFileWithOptions(): void
+    {
+        $path = sys_get_temp_dir() . '/toml_test_' . uniqid() . '.toml';
+
+        try {
+            Toml::encodeFile($path, ['zebra' => 1, 'apple' => 2], new EncoderOptions(sortKeys: true));
+
+            $content = file_get_contents($path);
+            $this->assertIsString($content);
+            $applePos = strpos($content, 'apple');
+            $zebraPos = strpos($content, 'zebra');
+
+            $this->assertLessThan($zebraPos, $applePos);
+        } finally {
+            @unlink($path);
+        }
+    }
+
+    public function testEncodeFileThrowsOnInvalidPath(): void
+    {
+        $this->expectException(EncodeException::class);
+        $this->expectExceptionMessage('Cannot write file');
+
+        Toml::encodeFile('/nonexistent/directory/file.toml', ['key' => 'value']);
+    }
+
+    public function testEncodeDocumentFile(): void
+    {
+        $path = sys_get_temp_dir() . '/toml_test_' . uniqid() . '.toml';
+
+        try {
+            $doc = Toml::parse("title = \"Example\"\ncount = 10\n", true);
+            Toml::encodeDocumentFile($path, $doc, new EncoderOptions(documentFormatting: DocumentFormattingMode::SourceAware));
+
+            $this->assertFileExists($path);
+            $content = file_get_contents($path);
+            $this->assertSame("title = \"Example\"\ncount = 10\n", $content);
+        } finally {
+            @unlink($path);
+        }
+    }
+
+    public function testEncodeDocumentFileThrowsOnInvalidPath(): void
+    {
+        $this->expectException(EncodeException::class);
+        $this->expectExceptionMessage('Cannot write file');
+
+        $doc = Toml::parse('key = "value"');
+        Toml::encodeDocumentFile('/nonexistent/directory/file.toml', $doc);
     }
 }


### PR DESCRIPTION
## Summary

Add file writing convenience methods to the Toml facade:

- `encodeFile(path, data, options)`: Encode PHP array to TOML and write to file
- `encodeDocumentFile(path, doc, options)`: Encode AST document to TOML and write to file

## Usage

```php
// Encode array directly to file
Toml::encodeFile('/path/to/config.toml', $data);

// With options
Toml::encodeFile('/path/to/config.toml', $data, new EncoderOptions(sortKeys: true));

// Encode document to file (e.g., after AST editing)
$doc = Toml::parse($input, true);
// ... modify $doc ...
Toml::encodeDocumentFile('/path/to/output.toml', $doc, new EncoderOptions(
    documentFormatting: DocumentFormattingMode::SourceAware
));
```

## Details

- Both methods throw `EncodeException` on write failure
- Consistent with existing `decodeFile()` pattern
- All encoder options supported
- Full test coverage including error cases