### PR TITLE
fix: reject content after table headers

### DIFF
--- a/src/Parser/Parser.php
+++ b/src/Parser/Parser.php
@@ -92,6 +92,9 @@ final class Parser
             if ($token->is(TokenType::LeftBracket)) {
                 $table = $this->parseTableHeader();
                 if ($table !== null) {
+                    // TOML requires table headers to be on a line by themselves
+                    $this->checkTableHeaderTerminator();
+
                     if ($this->preserveTrivia) {
                         $table->setLeadingTrivia($leadingTrivia);
                         $table->setTrailingTrivia($this->collectTrailingTrivia());
@@ -651,6 +654,39 @@ final class Parser
         while ($this->check(TokenType::Whitespace)) {
             $this->advance();
         }
+    }
+
+    /**
+     * Check that a table header is properly terminated.
+     * TOML requires table headers to be on a line by themselves.
+     */
+    private function checkTableHeaderTerminator(): void
+    {
+        $token = $this->current();
+
+        // Direct valid terminators
+        if ($token->is(TokenType::Newline, TokenType::Eof, TokenType::Comment)) {
+            return;
+        }
+
+        // If whitespace, peek ahead to check what follows
+        if ($token->is(TokenType::Whitespace)) {
+            $peekPos = $this->pos + 1;
+            $tokenCount = count($this->tokens);
+            while ($peekPos < $tokenCount && $this->tokens[$peekPos]->is(TokenType::Whitespace)) {
+                $peekPos++;
+            }
+            if ($peekPos < $tokenCount) {
+                $nextToken = $this->tokens[$peekPos];
+                if ($nextToken->is(TokenType::Newline, TokenType::Eof, TokenType::Comment)) {
+                    return;
+                }
+            } else {
+                return;
+            }
+        }
+
+        $this->error('Expected newline or comment after table header', $token->span);
     }
 
     /**

--- a/tests/TomlTest.php
+++ b/tests/TomlTest.php
@@ -216,6 +216,46 @@ TOML);
         Toml::decode("a = []\n[[a]]\nb = 1\n");
     }
 
+    public function testDecodeRejectsContentAfterTableHeader(): void
+    {
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage('Expected newline or comment after table header');
+
+        // TOML spec: table headers must be on a line by themselves
+        Toml::decode("[table] key = \"value\"\n");
+    }
+
+    public function testDecodeRejectsContentAfterArrayTableHeader(): void
+    {
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage('Expected newline or comment after table header');
+
+        Toml::decode("[[array]] key = \"value\"\n");
+    }
+
+    public function testDecodeAcceptsCommentAfterTableHeader(): void
+    {
+        // Comments after table headers are valid
+        $result = Toml::decode("[table] # this is a comment\nkey = \"value\"\n");
+
+        $this->assertSame([
+            'table' => [
+                'key' => 'value',
+            ],
+        ], $result);
+    }
+
+    public function testDecodeAcceptsWhitespaceBeforeCommentAfterTableHeader(): void
+    {
+        $result = Toml::decode("[table]   # comment with leading spaces\nkey = \"value\"\n");
+
+        $this->assertSame([
+            'table' => [
+                'key' => 'value',
+            ],
+        ], $result);
+    }
+
     public function testEncodeSupportsExplicitLocalTemporalValues(): void
     {
         $encoded = Toml::encode([


### PR DESCRIPTION
## Summary

TOML spec requires table headers to be "on a line by themselves". The parser was incorrectly accepting invalid syntax like:

```toml
[table] key = "value"
```

This PR adds validation to reject content after table headers while still allowing valid comments:

```toml
[table] # this comment is valid
key = "value"
```

## Changes

- Add `checkTableHeaderTerminator()` method that validates table headers are followed only by newline, EOF, comment, or whitespace leading to those
- Call the terminator check after successfully parsing table headers
- Add tests for rejection and acceptance cases

## Test Coverage

- `testDecodeRejectsContentAfterTableHeader` - rejects `[table] key = "value"`
- `testDecodeRejectsContentAfterArrayTableHeader` - rejects `[[array]] key = "value"`
- `testDecodeAcceptsCommentAfterTableHeader` - accepts `[table] # comment`
- `testDecodeAcceptsWhitespaceBeforeCommentAfterTableHeader` - accepts `[table]   # comment`