### PR TITLE
Validate encodeDocument() semantics and tighten parser edge cases

### DIFF
--- a/src/Encoder/Encoder.php
+++ b/src/Encoder/Encoder.php
@@ -49,10 +49,15 @@ final class Encoder
 
     public function encodeDocument(Document $doc): string
     {
-        if ($this->options->documentFormatting === DocumentFormattingMode::Normalized || !$this->documentHasTrivia($doc)) {
-            $normalizer = new Normalizer();
+        $normalizer = new Normalizer();
+        $normalized = $normalizer->normalize($doc);
+        $errors = $normalizer->getErrors();
+        if ($errors !== []) {
+            throw new EncodeException($errors[0]->message);
+        }
 
-            return $this->encode($normalizer->normalize($doc));
+        if ($this->options->documentFormatting === DocumentFormattingMode::Normalized || !$this->documentHasTrivia($doc)) {
+            return $this->encode($normalized);
         }
 
         return $this->encodeAstItems($doc->items);

--- a/src/Lexer/Lexer.php
+++ b/src/Lexer/Lexer.php
@@ -329,6 +329,12 @@ final class Lexer
                 }
 
                 if ($tempPos < $this->length && ($this->input[$tempPos] === "\n" || $this->input[$tempPos] === "\r")) {
+                    if ($this->input[$tempPos] === "\r" && ($tempPos + 1 >= $this->length || $this->input[$tempPos + 1] !== "\n")) {
+                        $valid = false;
+                        $this->pos = $tempPos + 1;
+
+                        continue;
+                    }
                     // Line continuation: skip to next non-whitespace
                     $this->pos = $tempPos;
                     $this->skipWhitespaceAndNewlines();

--- a/src/Parser/Parser.php
+++ b/src/Parser/Parser.php
@@ -250,16 +250,26 @@ final class Parser
                 $parts[] = $token->parsed;
                 $styles[] = KeyStyle::Literal;
                 $this->advance();
-            } elseif ($token->is(TokenType::Integer) || $token->is(TokenType::Boolean)) {
-                // TOML 1.1: numbers and booleans are valid bare keys
+            } elseif ($token->is(TokenType::Integer)) {
+                // Integer-looking tokens can be bare keys only when they are unsigned decimal digits.
+                if (preg_match('/^\d[\d_]*$/', $token->value) !== 1) {
+                    $this->error('Expected key', $token->span);
+
+                    return null;
+                }
+                $parts[] = $token->value;
+                $styles[] = KeyStyle::Bare;
+                $this->advance();
+            } elseif ($token->is(TokenType::Boolean)) {
+                // TOML 1.1: booleans are valid bare keys
                 $parts[] = $token->value;
                 $styles[] = KeyStyle::Bare;
                 $this->advance();
             } elseif ($token->is(TokenType::Float)) {
                 // TOML 1.1: float-like tokens may be dotted keys (e.g., 1.2 = "a.b")
                 $value = $token->value;
-                // Check if it's a simple dotted key (no exponent, just digit.digit)
-                if (preg_match('/^[+-]?\d+\.\d+$/', str_replace('_', '', $value)) && !str_contains(strtolower($value), 'e')) {
+                // Check if it's a simple unsigned dotted key (no exponent, just digit.digit)
+                if (preg_match('/^\d+\.\d+$/', str_replace('_', '', $value)) === 1 && !str_contains(strtolower($value), 'e')) {
                     // Split into parts at the dot
                     $dotParts = explode('.', $value);
                     foreach ($dotParts as $part) {
@@ -270,8 +280,9 @@ final class Parser
                     // Remove the extra separator we added
                     array_pop($rawSeparators);
                 } else {
-                    $parts[] = $value;
-                    $styles[] = KeyStyle::Bare;
+                    $this->error('Expected key', $token->span);
+
+                    return null;
                 }
                 $this->advance();
             } elseif ($token->is(TokenType::LocalDate, TokenType::LocalTime, TokenType::LocalDateTime, TokenType::OffsetDateTime)) {

--- a/tests/TomlTest.php
+++ b/tests/TomlTest.php
@@ -180,6 +180,30 @@ TOML);
         Toml::decode("d = 2024-01-01T00:00:00+99:00\n");
     }
 
+    public function testDecodeRejectsSignedIntegerKey(): void
+    {
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage('Expected key');
+
+        Toml::decode("+1 = 2\n");
+    }
+
+    public function testDecodeRejectsSignedFloatLikeKey(): void
+    {
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage('Expected key');
+
+        Toml::decode("+1.2 = 3\n");
+    }
+
+    public function testDecodeRejectsBareCrInMultilineBasicStringContinuation(): void
+    {
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage('Invalid token');
+
+        Toml::decode("x = \"\"\"a\\\rb\"\"\"\n");
+    }
+
     public function testTryParseReportsSemanticErrors(): void
     {
         $result = Toml::tryParse("a = 1\n[a]\nb = 2\n");
@@ -341,5 +365,30 @@ TOML);
 
         $doc = Toml::parse('key = "value"');
         Toml::encodeDocumentFile('/nonexistent/directory/file.toml', $doc);
+    }
+
+    public function testEncodeDocumentRejectsSemanticallyInvalidAstInNormalizedMode(): void
+    {
+        $doc = Toml::parse("a = 1\n");
+        $doc->items[] = clone $doc->items[0];
+
+        $this->expectException(EncodeException::class);
+        $this->expectExceptionMessage("Duplicate key 'a'");
+
+        Toml::encodeDocument($doc);
+    }
+
+    public function testEncodeDocumentRejectsSemanticallyInvalidAstInSourceAwareMode(): void
+    {
+        $doc = Toml::parse("a = 1\n", true);
+        $doc->items[] = clone $doc->items[0];
+
+        $this->expectException(EncodeException::class);
+        $this->expectExceptionMessage("Duplicate key 'a'");
+
+        Toml::encodeDocument(
+            $doc,
+            new EncoderOptions(documentFormatting: DocumentFormattingMode::SourceAware),
+        );
     }
 }


### PR DESCRIPTION
## Summary
- validate AST semantics before `encodeDocument()` emits normalized or source-aware output
- reject signed numeric-looking keys in parser key position
- reject bare CR in multiline basic string line continuations
- add regressions for all three cases

## Verification
- `vendor/bin/phpunit tests/TomlTest.php tests/Lexer/LexerTest.php`
- `vendor/bin/phpunit`
- `vendor/bin/phpstan analyse`
- `vendor/bin/phpcs --colors --parallel=16`
