### PR TITLE
fix: enforce inline table and static array immutability

### DIFF
--- a/docs/reference/support-matrix.md
+++ b/docs/reference/support-matrix.md
@@ -118,18 +118,18 @@ Tested against [toml-test](https://github.com/toml-lang/toml-test) v2.1.0:
 | Test Type | Passed | Failed | Compliance |
 |-----------|--------|--------|------------|
 | Valid | 213 | 1 | 99.5% |
-| Invalid | 459 | 7 | 98.5% |
+| Invalid | 466 | 9 | 98.1% |
 
 ### TOML 1.0
 
 | Test Type | Passed | Failed | Compliance |
 |-----------|--------|--------|------------|
 | Valid | 204 | 1 | 99.5% |
-| Invalid | 459 | 14 | 97.0% |
+| Invalid | 466 | 17 | 96.5% |
 
 The single valid test failure is due to a PHP limitation with null byte property names.
 
-The remaining invalid test failures are edge cases around comment control characters and specific datetime validation patterns.
+The remaining invalid test failures are TOML 1.0 strict tests for features that TOML 1.1 relaxes (multiline inline tables, trailing commas, `\xHH` escapes, optional seconds in times).
 
 ## Recommended Use
 

--- a/src/Normalizer.php
+++ b/src/Normalizer.php
@@ -48,6 +48,13 @@ final class Normalizer
     private array $sealedInlineTables = [];
 
     /**
+     * Keys that are static arrays (defined via = [...]) whose elements cannot be extended.
+     *
+     * @var array<string, \PhpCollective\Toml\Lexer\Span>
+     */
+    private array $staticArrays = [];
+
+    /**
      * @return array<string, mixed>
      */
     public function normalize(Document $doc): array
@@ -58,6 +65,7 @@ final class Normalizer
         $this->activeDisplayPath = [];
         $this->activeInternalPath = [];
         $this->sealedInlineTables = [];
+        $this->staticArrays = [];
         $result = [];
 
         foreach ($doc->items as $item) {
@@ -66,6 +74,9 @@ final class Normalizer
                 $this->setDocumentValue($result, $item->key->parts, $normalized['value'], $item->getSpan());
                 if ($normalized['isInlineTable']) {
                     $this->sealedInlineTables[$this->pathId($item->key->parts)] = $item->getSpan();
+                }
+                if ($normalized['isStaticArray']) {
+                    $this->staticArrays[$this->pathId($item->key->parts)] = $item->getSpan();
                 }
             } elseif ($item instanceof Table) {
                 $this->processTable($result, $item);
@@ -115,6 +126,10 @@ final class Normalizer
                 $fullPath = [...$this->activeInternalPath, ...$kv->key->parts];
                 $this->sealedInlineTables[$this->pathId($fullPath)] = $kv->getSpan();
             }
+            if ($normalized['isStaticArray']) {
+                $fullPath = [...$this->activeInternalPath, ...$kv->key->parts];
+                $this->staticArrays[$this->pathId($fullPath)] = $kv->getSpan();
+            }
         }
     }
 
@@ -149,7 +164,7 @@ final class Normalizer
     }
 
     /**
-     * @return array{value: mixed, isInlineTable: bool}
+     * @return array{value: mixed, isInlineTable: bool, isStaticArray: bool}
      */
     private function normalizeValue(Value $value): array
     {
@@ -157,6 +172,7 @@ final class Normalizer
             return [
                 'value' => array_map(fn (Value $item) => $this->normalizeValue($item)['value'], $value->items),
                 'isInlineTable' => false,
+                'isStaticArray' => true,
             ];
         }
 
@@ -164,6 +180,8 @@ final class Normalizer
             $result = [];
             $inlineDefinedTables = [];
             $inlineDefinedKeys = [];
+            $inlineSealedTables = [];
+            $inlineStaticArrays = [];
 
             foreach ($value->items as $kv) {
                 $normalized = $this->normalizeValue($kv->value);
@@ -176,14 +194,22 @@ final class Normalizer
                     $inlineDefinedKeys,
                     $kv->key->parts,
                     $kv->key->parts,
-                    true, // Inline tables have their own scope, don't check global sealed tables
+                    $inlineSealedTables,
+                    $inlineStaticArrays,
                 );
+                // Track sealed inline tables within this scope
+                if ($normalized['isInlineTable']) {
+                    $inlineSealedTables[$this->pathId($kv->key->parts)] = $kv->getSpan();
+                }
+                if ($normalized['isStaticArray']) {
+                    $inlineStaticArrays[$this->pathId($kv->key->parts)] = $kv->getSpan();
+                }
             }
 
-            return ['value' => $result, 'isInlineTable' => true];
+            return ['value' => $result, 'isInlineTable' => true, 'isStaticArray' => false];
         }
 
-        return ['value' => $value->getValue(), 'isInlineTable' => false];
+        return ['value' => $value->getValue(), 'isInlineTable' => false, 'isStaticArray' => false];
     }
 
     /**
@@ -202,6 +228,22 @@ final class Normalizer
         $leafKey = array_pop($path);
         if ($leafKey === null) {
             return $null;
+        }
+
+        // Check if any path component is a sealed inline table
+        $checkPath = [];
+        foreach ([...$path, $leafKey] as $key) {
+            $checkPath[] = $key;
+            $checkPathId = $this->pathId($checkPath);
+            if (isset($this->sealedInlineTables[$checkPathId])) {
+                $displayPath = implode('.', $checkPath);
+                $this->errors[] = new ParseError(
+                    "Cannot extend inline table '{$displayPath}'",
+                    $span,
+                );
+
+                return $null;
+            }
         }
 
         foreach ($path as $key) {
@@ -225,6 +267,16 @@ final class Normalizer
 
             $internalPrefix[] = $key;
             if ($current[$key] !== [] && array_is_list($current[$key])) {
+                // Check if this is a static array - cannot extend elements of static arrays
+                $internalPathId = $this->pathId($internalPrefix);
+                if (isset($this->staticArrays[$internalPathId])) {
+                    $this->errors[] = new ParseError(
+                        "Cannot extend values in static array '{$displayPath}'",
+                        $span,
+                    );
+
+                    return $null;
+                }
                 $lastEntry = array_key_last($current[$key]);
                 $internalPrefix[] = '#' . (string)$lastEntry;
                 $current = &$current[$key][$lastEntry];
@@ -304,6 +356,22 @@ final class Normalizer
             return $null;
         }
 
+        // Check if any path component is a sealed inline table
+        $checkPath = [];
+        foreach ([...$path, $leafKey] as $key) {
+            $checkPath[] = $key;
+            $checkPathId = $this->pathId($checkPath);
+            if (isset($this->sealedInlineTables[$checkPathId])) {
+                $displayPath = implode('.', $checkPath);
+                $this->errors[] = new ParseError(
+                    "Cannot extend inline table '{$displayPath}'",
+                    $span,
+                );
+
+                return $null;
+            }
+        }
+
         foreach ($path as $key) {
             $displayPrefix[] = $key;
             $displayPath = implode('.', $displayPrefix);
@@ -325,6 +393,16 @@ final class Normalizer
 
             $internalPrefix[] = $key;
             if ($current[$key] !== [] && array_is_list($current[$key])) {
+                // Check if this is a static array - cannot extend elements of static arrays
+                $internalPathId = $this->pathId($internalPrefix);
+                if (isset($this->staticArrays[$internalPathId])) {
+                    $this->errors[] = new ParseError(
+                        "Cannot extend values in static array '{$displayPath}'",
+                        $span,
+                    );
+
+                    return $null;
+                }
                 $lastEntry = array_key_last($current[$key]);
                 $internalPrefix[] = '#' . (string)$lastEntry;
                 $current = &$current[$key][$lastEntry];
@@ -378,7 +456,8 @@ final class Normalizer
      * @param array<string, \PhpCollective\Toml\Lexer\Span> $definedKeys
      * @param array<string> $displayFullPath
      * @param array<string> $internalFullPath
-     * @param bool $isInlineTableScope When true, skip global sealed table check (inline tables have their own scope)
+     * @param array<string, \PhpCollective\Toml\Lexer\Span>|null $scopeSealedTables Sealed tables for inline scope (null = use global)
+     * @param array<string, \PhpCollective\Toml\Lexer\Span>|null $scopeStaticArrays Static arrays for inline scope (null = use global)
      */
     private function setNestedValue(
         array &$array,
@@ -389,26 +468,37 @@ final class Normalizer
         array &$definedKeys,
         array $displayFullPath,
         array $internalFullPath,
-        bool $isInlineTableScope = false,
+        ?array $scopeSealedTables = null,
+        ?array $scopeStaticArrays = null,
     ): void {
         $current = &$array;
         $displayPrefix = array_slice($displayFullPath, 0, count($displayFullPath) - count($path));
         $internalPrefix = array_slice($internalFullPath, 0, count($internalFullPath) - count($path));
         $lastIndex = count($path) - 1;
 
-        // Check if we're extending a sealed inline table
-        // For path ['point', 'y'], if 'point' is sealed, reject it
-        // Skip this check inside inline tables - they have their own independent scope
-        if (!$isInlineTableScope) {
-            $checkPath = $displayPrefix;
-            foreach ($path as $i => $key) {
-                $checkPath[] = $key;
-                $checkPathStr = implode('.', $checkPath);
-                $checkPathId = $this->pathId($checkPath);
-                // If this intermediate path is sealed AND there's more path to traverse, reject
-                if ($i < $lastIndex && isset($this->sealedInlineTables[$checkPathId])) {
+        // Determine which sealed tables and static arrays to check
+        $sealedTables = $scopeSealedTables ?? $this->sealedInlineTables;
+        $staticArrays = $scopeStaticArrays ?? $this->staticArrays;
+
+        // Check if we're extending a sealed inline table or static array
+        $checkPath = $displayPrefix;
+        foreach ($path as $i => $key) {
+            $checkPath[] = $key;
+            $checkPathStr = implode('.', $checkPath);
+            $checkPathId = $this->pathId($checkPath);
+            // If this intermediate path is sealed AND there's more path to traverse, reject
+            if ($i < $lastIndex) {
+                if (isset($sealedTables[$checkPathId])) {
                     $this->errors[] = new ParseError(
                         "Cannot extend inline table '{$checkPathStr}' with dotted keys",
+                        $span,
+                    );
+
+                    return;
+                }
+                if (isset($staticArrays[$checkPathId])) {
+                    $this->errors[] = new ParseError(
+                        "Cannot extend static array '{$checkPathStr}' with dotted keys",
                         $span,
                     );
 
@@ -456,8 +546,8 @@ final class Normalizer
             }
 
             // Check if this intermediate path was explicitly defined as a table or array table
-            // If so, we cannot extend it with dotted keys
-            if (!$isInlineTableScope && isset($this->definedTables[$internalPath])) {
+            // If so, we cannot extend it with dotted keys (only for global scope)
+            if ($scopeSealedTables === null && isset($this->definedTables[$internalPath])) {
                 $kind = $this->definedTables[$internalPath]['kind'];
                 if ($kind === 'explicit' || $kind === 'array') {
                     $this->errors[] = new ParseError(

--- a/tests/Conformance/SpecEdgeCaseTest.php
+++ b/tests/Conformance/SpecEdgeCaseTest.php
@@ -54,6 +54,6 @@ y = 2
 TOML);
 
         $this->assertFalse($result->isValid());
-        $this->assertSame("Cannot redefine key 'point' as a table", $result->getErrors()[0]->message);
+        $this->assertSame("Cannot extend inline table 'point'", $result->getErrors()[0]->message);
     }
 }

--- a/tests/TomlTest.php
+++ b/tests/TomlTest.php
@@ -203,7 +203,7 @@ TOML);
     public function testDecodeRejectsReopeningInlineTableAsRegularTable(): void
     {
         $this->expectException(ParseException::class);
-        $this->expectExceptionMessage("Cannot redefine key 'a' as a table");
+        $this->expectExceptionMessage("Cannot extend inline table 'a'");
 
         Toml::decode("a = { b = 1 }\n[a]\nc = 2\n");
     }
@@ -254,6 +254,33 @@ TOML);
                 'key' => 'value',
             ],
         ], $result);
+    }
+
+    public function testDecodeRejectsExtendingStaticArrayElements(): void
+    {
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage("Cannot extend values in static array 'a'");
+
+        // Static arrays (defined via = [...]) cannot have their elements extended
+        Toml::decode("a = [{ b = 1 }]\n[a.c]\nfoo = 1\n");
+    }
+
+    public function testDecodeRejectsExtendingInlineTableWithinInlineTable(): void
+    {
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage("Cannot extend inline table 'inner' with dotted keys");
+
+        // Within an inline table, nested inline tables are immutable
+        Toml::decode("tab = { inner = { dog = \"best\" }, inner.cat = \"worst\" }\n");
+    }
+
+    public function testDecodeRejectsExtendingStaticArrayWithinInlineTable(): void
+    {
+        $this->expectException(ParseException::class);
+        $this->expectExceptionMessage("Cannot extend static array 'inner.table' with dotted keys");
+
+        // Within an inline table, static arrays are immutable
+        Toml::decode("tab = { inner.table = [{}], inner.table.val = \"bad\" }\n");
     }
 
     public function testEncodeSupportsExplicitLocalTemporalValues(): void


### PR DESCRIPTION
## Summary

TOML spec requires that inline tables and static arrays (arrays defined via `= [...]`) are immutable and cannot be extended after definition. This PR enforces that constraint.

## Changes

- Add `staticArrays` tracking to reject extending array elements via table headers
- Check sealed inline tables in `openTable`/`openArrayTable` before traversing
- Track sealed tables within inline table scope for nested immutability validation
- Update `setNestedValue` to accept scope-local sealed tables and static arrays

## Fixed Cases

| Test | Issue |
|------|-------|
| `array/extending-table.toml` | `a = [{}]` then `[a.b]` now rejected |
| `inline-table/overwrite-02.toml` | `a = {}` then `[a.b]` now rejected |
| `inline-table/overwrite-07.toml` | `{ inner.table = [{}], inner.table.val = "x" }` now rejected |
| `inline-table/overwrite-08.toml` | `{ inner = {}, inner.cat = "x" }` now rejected |
| `inline-table/duplicate-key-03.toml` | Duplicate via dotted paths in inline table now rejected |

## Compliance

| Version | Invalid Tests | Compliance |
|---------|---------------|------------|
| TOML 1.1 | 466/475 | 98.1% |
| TOML 1.0 | 466/483 | 96.5% |

The 9 remaining failures for TOML 1.1 are strict TOML 1.0 tests for features that 1.1 relaxes (multiline inline tables, trailing commas, `\xHH` escapes, optional seconds).