### PR TITLE
Improve error recovery in collections

### DIFF
--- a/src/Parser/Parser.php
+++ b/src/Parser/Parser.php
@@ -34,6 +34,16 @@ use PhpCollective\Toml\TomlVersion;
 final class Parser
 {
     /**
+     * @var string
+     */
+    private const CONTEXT_ARRAY = 'array';
+
+    /**
+     * @var string
+     */
+    private const CONTEXT_INLINE_TABLE = 'inline_table';
+
+    /**
      * @var array<\PhpCollective\Toml\Parser\ParseError>
      */
     private array $errors = [];
@@ -49,6 +59,14 @@ final class Parser
 
     private string $input = '';
 
+    /**
+     * Stack tracking nesting context for error recovery.
+     * Contains 'array' or 'inline_table' entries.
+     *
+     * @var array<string>
+     */
+    private array $contextStack = [];
+
     public function __construct(
         bool $preserveTrivia = false,
         private readonly TomlVersion $version = TomlVersion::V11,
@@ -63,6 +81,7 @@ final class Parser
         $this->tokens = iterator_to_array($lexer->tokenize());
         $this->pos = 0;
         $this->errors = [];
+        $this->contextStack = [];
 
         return $this->parseDocument();
     }
@@ -224,6 +243,156 @@ final class Parser
             $this->slicePrefixTo($span, $value->getSpan()),
             $this->sliceRange($key->getSpan()->end, $value->getSpan()->start),
         );
+    }
+
+    /**
+     * Parse a key-value pair inside an inline table.
+     * Unlike parseKeyValue(), this does not call synchronize() on error,
+     * allowing the inline table parser to handle recovery.
+     */
+    private function parseInlineTableKeyValue(): ?KeyValue
+    {
+        $start = $this->current()->span;
+        $key = $this->parseKeyWithoutSync();
+
+        if ($key === null) {
+            return null;
+        }
+
+        if (!$this->check(TokenType::Equals)) {
+            $hint = $this->getExpectHint(TokenType::Equals);
+            $this->error('Expected =', $this->current()->span, $hint);
+
+            return null;
+        }
+        $this->advance();
+
+        $this->skipWhitespace();
+
+        $value = $this->parseValue();
+        if ($value === null) {
+            $token = $this->current();
+            if ($token->is(TokenType::Invalid)) {
+                $hint = $this->getInvalidTokenHint($token->value);
+                $this->error("Invalid token: `{$token->value}`", $token->span, $hint);
+            } else {
+                $hint = $this->getExpectedValueHint($token);
+                $this->error('Expected value', $token->span, $hint);
+            }
+
+            return null;
+        }
+
+        $span = $start->merge($value->getSpan());
+
+        return new KeyValue(
+            $key,
+            $value,
+            $span,
+            $this->slice($span),
+            $this->slicePrefixTo($span, $value->getSpan()),
+            $this->sliceRange($key->getSpan()->end, $value->getSpan()->start),
+        );
+    }
+
+    /**
+     * Parse a key without calling synchronize() on error.
+     * Used for inline table key-value parsing where the parent handles recovery.
+     */
+    private function parseKeyWithoutSync(): ?Key
+    {
+        $parts = [];
+        $styles = [];
+        $start = null;
+        $rawSeparators = [];
+        $lastPartEnd = 0;
+        $separatorStart = null;
+
+        do {
+            $this->skipWhitespace();
+            $token = $this->current();
+            $start ??= $token->span;
+
+            if ($separatorStart !== null) {
+                $rawSeparators[] = $this->sliceRange($separatorStart, $token->span->start);
+                $separatorStart = null;
+            }
+
+            if ($token->is(TokenType::BareKey)) {
+                $parts[] = $token->parsed;
+                $styles[] = KeyStyle::Bare;
+                $this->advance();
+            } elseif ($token->is(TokenType::BasicString)) {
+                $parts[] = $token->parsed;
+                $styles[] = KeyStyle::Basic;
+                $this->advance();
+            } elseif ($token->is(TokenType::LiteralString)) {
+                $parts[] = $token->parsed;
+                $styles[] = KeyStyle::Literal;
+                $this->advance();
+            } elseif ($token->is(TokenType::Integer)) {
+                if (preg_match('/^[+-]?\d[\d_]*$/', $token->value) !== 1) {
+                    $this->error('Expected key', $token->span, 'Only decimal integers can be used as bare keys.');
+
+                    return null;
+                }
+                $parts[] = $token->value;
+                $styles[] = KeyStyle::Bare;
+                $this->advance();
+            } elseif ($token->is(TokenType::Invalid)) {
+                if (preg_match('/^[A-Za-z0-9_-]+$/', $token->value) !== 1) {
+                    $hint = $this->getExpectedKeyHint($token);
+                    $this->error('Expected key', $token->span, $hint);
+
+                    return null;
+                }
+                $parts[] = $token->value;
+                $styles[] = KeyStyle::Bare;
+                $this->advance();
+            } elseif ($token->is(TokenType::Boolean)) {
+                $parts[] = $token->value;
+                $styles[] = KeyStyle::Bare;
+                $this->advance();
+            } elseif ($token->is(TokenType::Float)) {
+                $value = $token->value;
+                if (preg_match('/^\d+\.\d+$/', str_replace('_', '', $value)) === 1 && !str_contains(strtolower($value), 'e')) {
+                    $dotParts = explode('.', $value);
+                    foreach ($dotParts as $part) {
+                        $parts[] = $part;
+                        $styles[] = KeyStyle::Bare;
+                        $rawSeparators[] = '.';
+                    }
+                    array_pop($rawSeparators);
+                } else {
+                    $parts[] = $value;
+                    $styles[] = KeyStyle::Bare;
+                }
+                $this->advance();
+            } elseif ($token->is(TokenType::LocalDate, TokenType::LocalTime, TokenType::LocalDateTime, TokenType::OffsetDateTime)) {
+                $parts[] = $token->value;
+                $styles[] = KeyStyle::Bare;
+                $this->advance();
+            } else {
+                $hint = $this->getExpectedKeyHint($token);
+                $this->error('Expected key', $token->span, $hint);
+
+                return null;
+            }
+
+            $lastPartEnd = $token->span->end;
+            $this->skipWhitespace();
+            if ($this->match(TokenType::Dot)) {
+                $separatorStart = $lastPartEnd;
+
+                continue;
+            }
+
+            break;
+        } while (true);
+
+        $span = new Span($start->start, $lastPartEnd, $start->line, $start->column);
+
+        return new Key($parts, $styles, $span, $this->slice($span), null, null, $rawSeparators);
     }
 
     private function parseKey(): ?Key
@@ -450,6 +619,8 @@ final class Parser
 
     private function parseArray(): ArrayValue
     {
+        $this->contextStack[] = self::CONTEXT_ARRAY;
+
         $start = $this->current()->span;
         $this->advance(); // skip [
 
@@ -478,12 +649,12 @@ final class Parser
                 $token = $this->current();
                 if (!$this->check(TokenType::RightBracket)) {
                     $this->error('Expected value in array', $token->span);
-                    // Skip the problematic token to recover
-                    if ($this->match(TokenType::Comma)) {
-                        continue;
+                    // Recover within the array context
+                    if (!$this->synchronizeInCollection()) {
+                        break;
                     }
 
-                    break;
+                    continue;
                 }
 
                 break;
@@ -523,6 +694,8 @@ final class Parser
         $this->expect(TokenType::RightBracket);
         $span = $start->merge($this->previous()->span);
 
+        array_pop($this->contextStack);
+
         return new ArrayValue(
             $items,
             $span,
@@ -537,6 +710,8 @@ final class Parser
 
     private function parseInlineTable(): InlineTable
     {
+        $this->contextStack[] = self::CONTEXT_INLINE_TABLE;
+
         $start = $this->current()->span;
         $this->advance(); // skip {
 
@@ -559,12 +734,19 @@ final class Parser
                 break;
             }
 
-            $kv = $this->parseKeyValue();
+            $kv = $this->parseInlineTableKeyValue();
             if ($kv !== null) {
                 if ($this->preserveTrivia) {
                     $kv->setLeadingTrivia($nextLeadingTrivia);
                 }
                 $items[] = $kv;
+            } else {
+                // Failed to parse key-value, try to recover
+                if (!$this->synchronizeInCollection()) {
+                    break;
+                }
+
+                continue;
             }
 
             $trailingTrivia = $this->preserveTrivia ? $this->collectCollectionTrivia() : [];
@@ -576,7 +758,7 @@ final class Parser
                 if (!$this->match(TokenType::Comma)) {
                     break;
                 }
-                if ($kv !== null && $this->preserveTrivia) {
+                if ($this->preserveTrivia) {
                     $kv->setTrailingTrivia($trailingTrivia);
                 }
 
@@ -590,13 +772,15 @@ final class Parser
 
                     break;
                 }
-            } elseif ($kv !== null && $this->preserveTrivia) {
+            } elseif ($this->preserveTrivia) {
                 $kv->setTrailingTrivia($trailingTrivia);
             }
         }
 
         $this->expect(TokenType::RightBrace);
         $span = $start->merge($this->previous()->span);
+
+        array_pop($this->contextStack);
 
         if ($this->version === TomlVersion::V10) {
             if ($this->inlineTableIsMultiline($start)) {
@@ -1055,6 +1239,10 @@ final class Parser
         $this->errors[] = new ParseError($message, $span, $hint);
     }
 
+    /**
+     * Synchronize parser state after an error at the top level.
+     * Skips tokens until a newline or table header is found.
+     */
     private function synchronize(): void
     {
         while (!$this->isAtEnd()) {
@@ -1063,10 +1251,57 @@ final class Parser
 
                 return;
             }
+            // Stop at table header start for recovery
             if ($this->check(TokenType::LeftBracket)) {
                 return;
             }
             $this->advance();
         }
+    }
+
+    /**
+     * Synchronize parser state after an error inside a collection (array or inline table).
+     * Skips to the next comma or closing bracket/brace, allowing recovery within the collection.
+     *
+     * @return bool True if recovery found a comma (can continue parsing), false if hit closing bracket/brace or end
+     */
+    private function synchronizeInCollection(): bool
+    {
+        $depth = 0;
+
+        while (!$this->isAtEnd()) {
+            $token = $this->current();
+
+            // Track nested brackets to avoid stopping at wrong level
+            if ($token->is(TokenType::LeftBracket, TokenType::LeftBrace)) {
+                $depth++;
+                $this->advance();
+
+                continue;
+            }
+
+            if ($token->is(TokenType::RightBracket, TokenType::RightBrace)) {
+                if ($depth > 0) {
+                    $depth--;
+                    $this->advance();
+
+                    continue;
+                }
+
+                // At our level's closing bracket - stop without consuming
+                return false;
+            }
+
+            // At our level, comma means we can continue with next element
+            if ($depth === 0 && $token->is(TokenType::Comma)) {
+                $this->advance();
+
+                return true;
+            }
+
+            $this->advance();
+        }
+
+        return false;
     }
 }

--- a/tests/Parser/ErrorRecoveryTest.php
+++ b/tests/Parser/ErrorRecoveryTest.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCollective\Toml\Test\Parser;
+
+use PhpCollective\Toml\Ast\KeyValue;
+use PhpCollective\Toml\Ast\Value\ArrayValue;
+use PhpCollective\Toml\Ast\Value\InlineTable;
+use PhpCollective\Toml\Toml;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for improved error recovery in the parser.
+ *
+ * These tests verify that the parser can recover from errors inside collections
+ * (arrays, inline tables) without cascading errors and while preserving as much
+ * of the document structure as possible.
+ */
+final class ErrorRecoveryTest extends TestCase
+{
+    public function testRecoveryInInlineTableMissingValue(): void
+    {
+        $input = <<<'TOML'
+data = {name = , age = 30}
+other = "test"
+TOML;
+
+        $result = Toml::tryParse($input);
+
+        // Should only have 1 error for the missing value, not cascading errors
+        $this->assertCount(1, $result->getErrors());
+        $this->assertSame('Expected value', $result->getErrors()[0]->message);
+        $this->assertSame(1, $result->getErrors()[0]->span->line);
+
+        // Both document items should be parsed
+        $doc = $result->getDocument();
+        $this->assertCount(2, $doc->items);
+
+        $this->assertInstanceOf(KeyValue::class, $doc->items[0]);
+        $this->assertSame(['data'], $doc->items[0]->key->parts);
+
+        $this->assertInstanceOf(KeyValue::class, $doc->items[1]);
+        $this->assertSame(['other'], $doc->items[1]->key->parts);
+    }
+
+    public function testRecoveryInInlineTableRecoversContinuingItems(): void
+    {
+        $input = '{a = 1, b = , c = 3}';
+
+        $result = Toml::tryParse('t = ' . $input);
+
+        // Should only have 1 error
+        $this->assertCount(1, $result->getErrors());
+        $this->assertSame('Expected value', $result->getErrors()[0]->message);
+
+        // The inline table should have 2 items: a and c (b failed)
+        $doc = $result->getDocument();
+        $this->assertCount(1, $doc->items);
+        $this->assertInstanceOf(KeyValue::class, $doc->items[0]);
+
+        $inlineTable = $doc->items[0]->value;
+        $this->assertInstanceOf(InlineTable::class, $inlineTable);
+        $this->assertCount(2, $inlineTable->items);
+
+        $this->assertSame(['a'], $inlineTable->items[0]->key->parts);
+        $this->assertSame(['c'], $inlineTable->items[1]->key->parts);
+    }
+
+    public function testRecoveryInArrayOfInlineTables(): void
+    {
+        $input = <<<'TOML'
+data = [{a = 1}, {b = }, {c = 3}]
+other = "value"
+TOML;
+
+        $result = Toml::tryParse($input);
+
+        // Should only have 1 error for the missing value in second inline table
+        $this->assertCount(1, $result->getErrors());
+        $this->assertSame('Expected value', $result->getErrors()[0]->message);
+        $this->assertSame(1, $result->getErrors()[0]->span->line);
+
+        // Both document items should be parsed
+        $doc = $result->getDocument();
+        $this->assertCount(2, $doc->items);
+
+        $this->assertInstanceOf(KeyValue::class, $doc->items[0]);
+        $this->assertSame(['data'], $doc->items[0]->key->parts);
+
+        $this->assertInstanceOf(KeyValue::class, $doc->items[1]);
+        $this->assertSame(['other'], $doc->items[1]->key->parts);
+    }
+
+    public function testRecoveryInDeeplyNestedInlineTable(): void
+    {
+        $input = <<<'TOML'
+deep = {level1 = {level2 = {invalid = }}}
+after = "test"
+TOML;
+
+        $result = Toml::tryParse($input);
+
+        // Should only have 1 error for the missing value at the deepest level
+        $this->assertCount(1, $result->getErrors());
+        $this->assertSame('Expected value', $result->getErrors()[0]->message);
+        $this->assertSame(1, $result->getErrors()[0]->span->line);
+
+        // Both document items should be parsed
+        $doc = $result->getDocument();
+        $this->assertCount(2, $doc->items);
+
+        $this->assertInstanceOf(KeyValue::class, $doc->items[0]);
+        $this->assertSame(['deep'], $doc->items[0]->key->parts);
+
+        $this->assertInstanceOf(KeyValue::class, $doc->items[1]);
+        $this->assertSame(['after'], $doc->items[1]->key->parts);
+    }
+
+    public function testRecoveryInArrayWithInvalidValue(): void
+    {
+        // Tests that array recovery skips invalid values and continues
+        $input = <<<'TOML'
+arr = [1, , 3]
+other = 123
+TOML;
+
+        $result = Toml::tryParse($input);
+
+        // Should have 1 error for the empty array element
+        $this->assertCount(1, $result->getErrors());
+        $this->assertStringContainsString('Expected value', $result->getErrors()[0]->message);
+
+        // Both document items should be parsed
+        $doc = $result->getDocument();
+        $this->assertCount(2, $doc->items);
+    }
+
+    public function testRecoveryInNestedArrays(): void
+    {
+        $input = <<<'TOML'
+arr = [1, [2, , 4], 5]
+after = "test"
+TOML;
+
+        $result = Toml::tryParse($input);
+
+        // Should have 1 error for the empty nested array element
+        $this->assertCount(1, $result->getErrors());
+
+        // Both document items should be parsed
+        $doc = $result->getDocument();
+        $this->assertCount(2, $doc->items);
+    }
+
+    public function testTopLevelRecoveryStillWorks(): void
+    {
+        // Test that top-level synchronization still works
+        $input = <<<'TOML'
+[table
+key = "value"
+other = 123
+TOML;
+
+        $result = Toml::tryParse($input);
+
+        // Should have error for missing bracket
+        $this->assertGreaterThanOrEqual(1, count($result->getErrors()));
+
+        // The key-value pairs should be recovered
+        $doc = $result->getDocument();
+        $this->assertGreaterThanOrEqual(2, count($doc->items));
+    }
+
+    public function testMultipleInlineTableErrorsInSameTable(): void
+    {
+        $input = '{a = , b = , c = 3}';
+
+        $result = Toml::tryParse('t = ' . $input);
+
+        // Should have 2 errors (one for each missing value)
+        $this->assertCount(2, $result->getErrors());
+
+        // The inline table should have 1 item: c (a and b failed)
+        $doc = $result->getDocument();
+        $this->assertCount(1, $doc->items);
+        $this->assertInstanceOf(KeyValue::class, $doc->items[0]);
+
+        $inlineTable = $doc->items[0]->value;
+        $this->assertInstanceOf(InlineTable::class, $inlineTable);
+        $this->assertCount(1, $inlineTable->items);
+
+        $this->assertSame(['c'], $inlineTable->items[0]->key->parts);
+    }
+
+    public function testRecoveryPreservesValidArrayElements(): void
+    {
+        $input = 'arr = [1, 2, invalid, 4, 5]';
+
+        $result = Toml::tryParse($input);
+
+        // Should have error for the invalid element
+        $this->assertGreaterThanOrEqual(1, count($result->getErrors()));
+
+        // Array should still be created
+        $doc = $result->getDocument();
+        $this->assertCount(1, $doc->items);
+        $this->assertInstanceOf(KeyValue::class, $doc->items[0]);
+
+        $arr = $doc->items[0]->value;
+        $this->assertInstanceOf(ArrayValue::class, $arr);
+
+        // Should have parsed elements before and after the invalid one
+        $this->assertGreaterThanOrEqual(2, count($arr->items));
+    }
+}

--- a/tests/Parser/ErrorRecoveryTest.php
+++ b/tests/Parser/ErrorRecoveryTest.php
@@ -35,6 +35,7 @@ TOML;
 
         // Both document items should be parsed
         $doc = $result->getDocument();
+        $this->assertNotNull($doc);
         $this->assertCount(2, $doc->items);
 
         $this->assertInstanceOf(KeyValue::class, $doc->items[0]);
@@ -56,6 +57,7 @@ TOML;
 
         // The inline table should have 2 items: a and c (b failed)
         $doc = $result->getDocument();
+        $this->assertNotNull($doc);
         $this->assertCount(1, $doc->items);
         $this->assertInstanceOf(KeyValue::class, $doc->items[0]);
 
@@ -83,6 +85,7 @@ TOML;
 
         // Both document items should be parsed
         $doc = $result->getDocument();
+        $this->assertNotNull($doc);
         $this->assertCount(2, $doc->items);
 
         $this->assertInstanceOf(KeyValue::class, $doc->items[0]);
@@ -108,6 +111,7 @@ TOML;
 
         // Both document items should be parsed
         $doc = $result->getDocument();
+        $this->assertNotNull($doc);
         $this->assertCount(2, $doc->items);
 
         $this->assertInstanceOf(KeyValue::class, $doc->items[0]);
@@ -133,6 +137,7 @@ TOML;
 
         // Both document items should be parsed
         $doc = $result->getDocument();
+        $this->assertNotNull($doc);
         $this->assertCount(2, $doc->items);
     }
 
@@ -150,6 +155,7 @@ TOML;
 
         // Both document items should be parsed
         $doc = $result->getDocument();
+        $this->assertNotNull($doc);
         $this->assertCount(2, $doc->items);
     }
 
@@ -169,6 +175,7 @@ TOML;
 
         // The key-value pairs should be recovered
         $doc = $result->getDocument();
+        $this->assertNotNull($doc);
         $this->assertGreaterThanOrEqual(2, count($doc->items));
     }
 
@@ -183,6 +190,7 @@ TOML;
 
         // The inline table should have 1 item: c (a and b failed)
         $doc = $result->getDocument();
+        $this->assertNotNull($doc);
         $this->assertCount(1, $doc->items);
         $this->assertInstanceOf(KeyValue::class, $doc->items[0]);
 
@@ -204,6 +212,7 @@ TOML;
 
         // Array should still be created
         $doc = $result->getDocument();
+        $this->assertNotNull($doc);
         $this->assertCount(1, $doc->items);
         $this->assertInstanceOf(KeyValue::class, $doc->items[0]);
 


### PR DESCRIPTION
## Summary

Implements improved error recovery

- Add context-aware error recovery that prevents cascading errors when parsing malformed arrays and inline tables
- Add bracket stack tracking to monitor nesting context
- Implement `synchronizeInCollection()` that recovers to next comma or closing bracket instead of skipping to newline
- Update `parseArray()` and `parseInlineTable()` to use bracket-aware recovery

### Before vs After

```toml
data = [{a = 1}, {b = }, {c = 3}]
other = "value"
```

**Before**: 4 cascading errors
```
Line 1:22: Expected value
Line 2:0: Expected }
Line 2:0: Expected ]
Line 2:0: Expected newline or end of input after value
```

**After**: 1 precise error
```
Line 1:22: Expected value
```

This enables better IDE/tooling support by providing more accurate error locations and preserving more of the document structure.
