### PR TITLE
Fix strict TOML 1.0 inline table values

### DIFF
--- a/docs/guide/syntax.md
+++ b/docs/guide/syntax.md
@@ -234,7 +234,7 @@ point = { x = 1, y = 2 }
 animal = { type.name = "pug" }
 ```
 
-TOML 1.1 also allows multiline inline tables and trailing commas:
+TOML 1.1 also allows multiline inline-table layout and trailing commas:
 
 ```toml
 point = {

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -77,7 +77,7 @@ if ($result->isValid()) {
 
 Use `tryParse()` when you need diagnostics and a partial AST instead of exception-driven control flow.
 
-The default parser/decoder mode is TOML 1.1-compatible. Use `TomlVersion::V10` when you need strict TOML 1.0 rejection of 1.1-only features such as `\xHH`, `\e`, multiline inline tables, inline-table trailing commas, or local times without seconds.
+The default parser/decoder mode is TOML 1.1-compatible. Use `TomlVersion::V10` when you need strict TOML 1.0 rejection of 1.1-only features such as `\xHH`, `\e`, multiline inline-table layout, inline-table trailing commas, or local times without seconds.
 
 ### encode()
 

--- a/docs/reference/support-matrix.md
+++ b/docs/reference/support-matrix.md
@@ -62,7 +62,7 @@ The default API behavior is TOML 1.1-compatible. Strict TOML 1.0 parsing/decodin
 | Nested inline tables | Supported | |
 | Dotted keys inside inline tables | Supported | |
 | Inline table trailing commas | Supported | TOML 1.1; rejected in strict TOML 1.0 mode |
-| Multiline inline tables | Supported | TOML 1.1; rejected in strict TOML 1.0 mode |
+| Multiline inline-table layout | Supported | TOML 1.1; rejected in strict TOML 1.0 mode. TOML 1.0 still allows multiline array and string values inside inline tables |
 
 ## Encoding
 
@@ -121,19 +121,19 @@ Tested against [toml-test](https://github.com/toml-lang/toml-test) v2.1.0:
 
 | Test Type | Passed | Failed | Compliance |
 |-----------|--------|--------|------------|
-| Valid | 428 | 0 | 100% |
+| Valid | 214 | 0 | 100% |
 | Invalid | 466 | 0 | 100% |
 
 ### TOML 1.0
 
 | Test Type | Passed | Failed | Compliance |
 |-----------|--------|--------|------------|
-| Valid | 410 | 0 | 100% |
+| Valid | 205 | 0 | 100% |
 | Invalid | 473 | 0 | 100% |
 
 These results were measured against the library's `bin/toml-decoder` adapter for the `toml-test` tagged JSON format. TOML 1.1 results use the default adapter mode; TOML 1.0 results use `TOML_VERSION=1.0` so the decoder runs in strict TOML 1.0 mode.
 
-Strict TOML 1.0 mode closes the previously documented invalid-case gaps for syntax that TOML 1.1 relaxes: multiline inline tables, inline-table trailing commas, `\xHH` byte escapes, and optional seconds in local times/datetimes.
+Strict TOML 1.0 mode closes the previously documented invalid-case gaps for syntax that TOML 1.1 relaxes: multiline inline-table layout, inline-table trailing commas, `\xHH` byte escapes, and optional seconds in local times/datetimes.
 
 ## Recommended Use
 

--- a/src/Parser/Parser.php
+++ b/src/Parser/Parser.php
@@ -720,10 +720,11 @@ final class Parser
         $closingTrivia = [];
         $hasTrailingComma = false;
         $nextLeadingTrivia = $openingTrivia;
+        $hasInlineTableLayoutNewline = $this->triviaContainsNewline($openingTrivia);
 
         while (!$this->check(TokenType::RightBrace) && !$this->isAtEnd()) {
             if (!$this->preserveTrivia) {
-                $this->skipTriviaInCollection();
+                $hasInlineTableLayoutNewline = $this->skipTriviaInCollection() || $hasInlineTableLayoutNewline;
             }
 
             if ($this->check(TokenType::RightBrace)) {
@@ -750,8 +751,9 @@ final class Parser
             }
 
             $trailingTrivia = $this->preserveTrivia ? $this->collectCollectionTrivia() : [];
+            $hasInlineTableLayoutNewline = $this->triviaContainsNewline($trailingTrivia) || $hasInlineTableLayoutNewline;
             if (!$this->preserveTrivia) {
-                $this->skipTriviaInCollection();
+                $hasInlineTableLayoutNewline = $this->skipTriviaInCollection() || $hasInlineTableLayoutNewline;
             }
 
             if (!$this->check(TokenType::RightBrace)) {
@@ -763,8 +765,9 @@ final class Parser
                 }
 
                 $nextLeadingTrivia = $this->preserveTrivia ? $this->collectCollectionTrivia() : [];
+                $hasInlineTableLayoutNewline = $this->triviaContainsNewline($nextLeadingTrivia) || $hasInlineTableLayoutNewline;
                 if (!$this->preserveTrivia) {
-                    $this->skipTriviaInCollection();
+                    $hasInlineTableLayoutNewline = $this->skipTriviaInCollection() || $hasInlineTableLayoutNewline;
                 }
                 if ($this->check(TokenType::RightBrace)) {
                     $hasTrailingComma = true;
@@ -783,7 +786,7 @@ final class Parser
         array_pop($this->contextStack);
 
         if ($this->version === TomlVersion::V10) {
-            if ($this->inlineTableIsMultiline($start)) {
+            if ($hasInlineTableLayoutNewline) {
                 $this->error('Multiline inline tables require TOML 1.1', $span);
             }
 
@@ -802,11 +805,6 @@ final class Parser
             $this->slice($span),
             $this->inferSingleLineInlineTableStyle($items, $openingTrivia, $closingTrivia),
         );
-    }
-
-    private function inlineTableIsMultiline(Span $start): bool
-    {
-        return $start->line !== $this->previous()->span->line;
     }
 
     // Helper methods
@@ -1052,11 +1050,16 @@ final class Parser
         return null;
     }
 
-    private function skipTriviaInCollection(): void
+    private function skipTriviaInCollection(): bool
     {
+        $hasNewline = false;
+
         while ($this->check(TokenType::Whitespace) || $this->check(TokenType::Comment) || $this->check(TokenType::Newline)) {
+            $hasNewline = $this->check(TokenType::Newline) || $hasNewline;
             $this->advance();
         }
+
+        return $hasNewline;
     }
 
     /**
@@ -1103,6 +1106,20 @@ final class Parser
         }
 
         return $trivia;
+    }
+
+    /**
+     * @param array<\PhpCollective\Toml\Ast\Trivia> $trivia
+     */
+    private function triviaContainsNewline(array $trivia): bool
+    {
+        foreach ($trivia as $item) {
+            if ($item->kind === TriviaKind::Newline) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private function toTrivia(Token $token): Trivia

--- a/tests/PublicApi/VersioningTest.php
+++ b/tests/PublicApi/VersioningTest.php
@@ -58,6 +58,33 @@ final class VersioningTest extends TestCase
         $this->assertSame('Multiline inline tables require TOML 1.1', $result->getErrors()[0]->message);
     }
 
+    public function testDecodeAllowsMultilineArrayInsideInlineTableInToml10Mode(): void
+    {
+        $input = <<<'TOML'
+point = { values = [
+  1,
+  2,
+] }
+TOML;
+
+        $decoded = Toml::decode($input, TomlVersion::V10);
+
+        $this->assertSame(['point' => ['values' => [1, 2]]], $decoded);
+    }
+
+    public function testDecodeAllowsMultilineStringInsideInlineTableInToml10Mode(): void
+    {
+        $input = <<<'TOML'
+point = { text = """
+hello
+""" }
+TOML;
+
+        $decoded = Toml::decode($input, TomlVersion::V10);
+
+        $this->assertSame(['point' => ['text' => "hello\n"]], $decoded);
+    }
+
     public function testEncodeNormalizesLocalTimeForToml10Mode(): void
     {
         $encoded = Toml::encode([


### PR DESCRIPTION
## Summary

Fix strict TOML 1.0 parsing for inline tables that contain multiline array or multiline string values. TOML 1.0 forbids multiline inline-table layout, but newlines that belong to nested values are valid.

Also refresh the related support-matrix wording and verified toml-test v2.1.0 counts.

## Verification

- composer cs-fix
- composer test
- composer stan
- composer cs-check
- TOML_VERSION=1.0 /tmp/toml-test-bin/toml-test-v2.1.0-linux-amd64 test -toml 1.0 -timeout 5s -decoder=./bin/toml-decoder -color never
