### PR TITLE
Fix silent integer overflow: reject out-of-64-bit-range integers

### DIFF
--- a/src/Lexer/Lexer.php
+++ b/src/Lexer/Lexer.php
@@ -763,23 +763,31 @@ final class Lexer
 
         // Hex (lowercase 0x only, no sign)
         if (str_starts_with($clean, '0x')) {
-            $parsed = intval($clean, 16);
+            // hexdec() returns a float when the value exceeds the signed 64-bit range
+            $parsed = hexdec(substr($clean, 2));
+            if (!is_int($parsed)) {
+                return new Token(TokenType::Invalid, $value, null, $span);
+            }
 
             return new Token(TokenType::Integer, $value, $parsed, $span);
         }
 
         // Octal (lowercase 0o only, no sign)
         if (str_starts_with($clean, '0o')) {
-            $oct = substr($clean, 2);
-            $parsed = intval($oct, 8);
+            $parsed = octdec(substr($clean, 2));
+            if (!is_int($parsed)) {
+                return new Token(TokenType::Invalid, $value, null, $span);
+            }
 
             return new Token(TokenType::Integer, $value, $parsed, $span);
         }
 
         // Binary (lowercase 0b only, no sign)
         if (str_starts_with($clean, '0b')) {
-            $bin = substr($clean, 2);
-            $parsed = (int)bindec($bin);
+            $parsed = bindec(substr($clean, 2));
+            if (!is_int($parsed)) {
+                return new Token(TokenType::Invalid, $value, null, $span);
+            }
 
             return new Token(TokenType::Integer, $value, $parsed, $span);
         }
@@ -789,8 +797,14 @@ final class Lexer
             return new Token(TokenType::Float, $value, (float)$clean, $span);
         }
 
-        // Plain integer
-        return new Token(TokenType::Integer, $value, (int)$clean, $span);
+        // Plain integer; TOML integers are 64-bit signed, so reject out-of-range values
+        // instead of silently saturating to PHP_INT_MAX/PHP_INT_MIN via an (int) cast.
+        $parsed = filter_var($clean, FILTER_VALIDATE_INT);
+        if ($parsed === false) {
+            return new Token(TokenType::Invalid, $value, null, $span);
+        }
+
+        return new Token(TokenType::Integer, $value, $parsed, $span);
     }
 
     private function isNumberChar(string $char): bool

--- a/tests/Parser/IntegerRangeTest.php
+++ b/tests/Parser/IntegerRangeTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCollective\Toml\Test\Parser;
+
+use PhpCollective\Toml\Toml;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class IntegerRangeTest extends TestCase
+{
+    #[DataProvider('validIntegerProvider')]
+    public function testValidIntegerInRange(string $input, int $expected): void
+    {
+        $result = Toml::decode('x = ' . $input);
+        $this->assertSame($expected, $result['x']);
+    }
+
+    /**
+     * @return array<string, array{string, int}>
+     */
+    public static function validIntegerProvider(): array
+    {
+        return [
+            'decimal max' => ['9223372036854775807', PHP_INT_MAX],
+            'decimal min' => ['-9223372036854775808', PHP_INT_MIN],
+            'decimal grouped max' => ['9_223_372_036_854_775_807', PHP_INT_MAX],
+            'positive sign' => ['+99', 99],
+            'hex max' => ['0x7FFFFFFFFFFFFFFF', PHP_INT_MAX],
+            'octal' => ['0o777', 511],
+            'binary' => ['0b1010', 10],
+        ];
+    }
+
+    /**
+     * Out-of-range integers must be rejected, not silently saturated to PHP_INT_MAX/MIN.
+     */
+    #[DataProvider('overflowIntegerProvider')]
+    public function testOutOfRangeIntegerIsRejected(string $input): void
+    {
+        $parseResult = Toml::tryParse('x = ' . $input);
+        $this->assertFalse(
+            $parseResult->isValid(),
+            'Expected out-of-range integer to be rejected: ' . $input,
+        );
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function overflowIntegerProvider(): array
+    {
+        return [
+            'decimal just over max' => ['9223372036854775808'],
+            'decimal just under min' => ['-9223372036854775809'],
+            'decimal far over max' => ['99999999999999999999999999'],
+            'hex over max' => ['0x8000000000000000'],
+            'hex all ones' => ['0xFFFFFFFFFFFFFFFF'],
+            'octal over max' => ['0o1777777777777777777777'],
+            'binary over max' => ['0b' . str_repeat('1', 64)],
+        ];
+    }
+}


### PR DESCRIPTION
## Problem

Integer literals exceeding the signed 64-bit range were silently saturated to `PHP_INT_MAX`/`PHP_INT_MIN` by `(int)` casts in the lexer, instead of raising a parse error. This affected decimal, hex, octal, and binary forms.

The TOML spec defines integers as 64-bit signed; out-of-range values must be rejected. Silent saturation also contradicts this library's strict-validation contract and corrupts data without warning.

Repro before this change:

```toml
x = 99999999999999999999999999
```

decoded to `9223372036854775807` with no error.

## Fix

Detect overflow in `Lexer::classifyNumber()` and emit a `TokenType::Invalid` token (surfaced as a `ParseError`, thrown by `decode()` / collected by `tryParse()`):

- **decimal** — `filter_var($clean, FILTER_VALIDATE_INT)` returns `false` on overflow (handles leading sign; underscores already stripped)
- **hex / oct / bin** — `hexdec()` / `octdec()` / `bindec()` return a `float` when the value overflows int, so an `is_int()` check rejects it

In-range values (including `PHP_INT_MAX`, `PHP_INT_MIN`, grouped `9_223_372_036_854_775_807`) are unchanged.

## Tests

Boundary-valid and overflow cases for all four bases added in `tests/Parser/IntegerRangeTest.php`.

## Context

Found while triaging the 1.0.0 roadmap (issue #8). A correctness bug worth fixing before the stable 1.0.0 tag, since changing parse behavior afterward is harder under semver.
