### PR TITLE
Support PHP 8.1 on v1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,16 +2,16 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [master, v1]
   pull_request:
-    branches: [master]
+    branches: [master, v1]
 
 jobs:
   tests:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ['8.2', '8.4']
+        php: ['8.1', '8.2', '8.4']
 
     name: PHP ${{ matrix.php }}
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Latest Stable Version](https://img.shields.io/packagist/v/php-collective/toml?style=flat-square)](https://packagist.org/packages/php-collective/toml)
 [![Total Downloads](https://img.shields.io/packagist/dt/php-collective/toml?style=flat-square)](https://packagist.org/packages/php-collective/toml)
 [![PHPStan](https://img.shields.io/badge/PHPStan-level%208-brightgreen.svg?style=flat-square)](https://phpstan.org/)
-[![PHP Version](https://img.shields.io/badge/php-%3E%3D8.2-8892BF.svg?style=flat-square)](https://php.net)
+[![PHP Version](https://img.shields.io/badge/php-%3E%3D8.1-8892BF.svg?style=flat-square)](https://php.net)
 [![Software License](https://img.shields.io/badge/license-MIT-green.svg?style=flat-square)](LICENSE)
 
 A [TOML](https://toml.io/) (v1.0 and v1.1) parser and encoder for PHP with AST access and collected parse errors.
@@ -22,7 +22,7 @@ A [TOML](https://toml.io/) (v1.0 and v1.1) parser and encoder for PHP with AST a
 
 ## Requirements
 
-- PHP 8.2 or higher
+- PHP 8.1 or higher
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,11 @@
     ],
     "homepage": "https://php-collective.github.io/toml/",
     "require": {
-        "php": ">=8.2",
+        "php": ">=8.1",
         "symfony/polyfill-mbstring": "^1.30"
     },
     "require-dev": {
-        "phpunit/phpunit": "^11.5 || ^12.5 || ^13.0",
+        "phpunit/phpunit": "^10.5 || ^11.5 || ^12.5 || ^13.0",
         "phpstan/phpstan": "^2.0",
         "php-collective/code-sniffer": "dev-master"
     },

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -10,7 +10,7 @@ Install via Composer:
 composer require php-collective/toml
 ```
 
-**Requirements:** PHP 8.2+
+**Requirements:** PHP 8.1+
 
 ## Quick Start
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ layout: home
 hero:
   name: PHP Toml
   text: TOML 1.0/1.1 Parser
-  tagline: A modern PHP 8.2+ parser and encoder with AST access, trivia preservation, and error recovery
+  tagline: A modern PHP 8.1+ parser and encoder with AST access, trivia preservation, and error recovery
   image:
     src: /logo.svg
     alt: PHP Toml
@@ -31,7 +31,7 @@ features:
     details: Full abstract syntax tree for analysis, transformation, or editor integrations
   - icon: ⚡
     title: Zero Dependencies
-    details: No required extensions - pure PHP 8.2+ with optional php-ds for performance
+    details: No required extensions - pure PHP 8.1+ with optional php-ds for performance
   - icon: 🔄
     title: Structured Re-Encode
     details: Parse TOML to an AST, modify nodes, and re-encode with partial trivia and layout preservation

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,7 +5,6 @@
          colors="true"
          cacheDirectory=".phpunit.cache"
          executionOrder="depends,defects"
-         shortenArraysForExportThreshold="10"
          displayDetailsOnTestsThatTriggerWarnings="true"
          displayDetailsOnTestsThatTriggerDeprecations="true"
          displayDetailsOnIncompleteTests="true"

--- a/src/Encoder/EncoderOptions.php
+++ b/src/Encoder/EncoderOptions.php
@@ -6,20 +6,20 @@ namespace PhpCollective\Toml\Encoder;
 
 use PhpCollective\Toml\TomlVersion;
 
-final readonly class EncoderOptions
+final class EncoderOptions
 {
     public function __construct(
-        public bool $sortKeys = false,
-        public string $newline = "\n",
-        public DocumentFormattingMode $documentFormatting = DocumentFormattingMode::Normalized,
-        public bool $skipNulls = false,
-        public TomlVersion $version = TomlVersion::V10,
-        public bool $integerGrouping = false,
-        public bool $trailingComma = false,
-        public bool $dottedKeys = false,
-        public ArrayStyle $arrayStyle = ArrayStyle::Inline,
-        public int $arrayAutoThreshold = 3,
-        public string $indent = '    ',
+        public readonly bool $sortKeys = false,
+        public readonly string $newline = "\n",
+        public readonly DocumentFormattingMode $documentFormatting = DocumentFormattingMode::Normalized,
+        public readonly bool $skipNulls = false,
+        public readonly TomlVersion $version = TomlVersion::V10,
+        public readonly bool $integerGrouping = false,
+        public readonly bool $trailingComma = false,
+        public readonly bool $dottedKeys = false,
+        public readonly ArrayStyle $arrayStyle = ArrayStyle::Inline,
+        public readonly int $arrayAutoThreshold = 3,
+        public readonly string $indent = '    ',
     ) {
     }
 

--- a/src/Lexer/Span.php
+++ b/src/Lexer/Span.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace PhpCollective\Toml\Lexer;
 
-final readonly class Span
+final class Span
 {
     public function __construct(
-        public int $start,
-        public int $end,
-        public int $line,
-        public int $column,
+        public readonly int $start,
+        public readonly int $end,
+        public readonly int $line,
+        public readonly int $column,
     ) {
     }
 

--- a/src/Lexer/Token.php
+++ b/src/Lexer/Token.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace PhpCollective\Toml\Lexer;
 
-final readonly class Token
+final class Token
 {
     public function __construct(
-        public TokenType $type,
-        public string $value,
-        public mixed $parsed,
-        public Span $span,
+        public readonly TokenType $type,
+        public readonly string $value,
+        public readonly mixed $parsed,
+        public readonly Span $span,
     ) {
     }
 

--- a/src/Parser/ParseError.php
+++ b/src/Parser/ParseError.php
@@ -6,12 +6,12 @@ namespace PhpCollective\Toml\Parser;
 
 use PhpCollective\Toml\Lexer\Span;
 
-final readonly class ParseError
+final class ParseError
 {
     public function __construct(
-        public string $message,
-        public Span $span,
-        public ?string $hint = null,
+        public readonly string $message,
+        public readonly Span $span,
+        public readonly ?string $hint = null,
     ) {
     }
 

--- a/src/Parser/ParseResult.php
+++ b/src/Parser/ParseResult.php
@@ -6,7 +6,7 @@ namespace PhpCollective\Toml\Parser;
 
 use PhpCollective\Toml\Ast\Document;
 
-final readonly class ParseResult
+final class ParseResult
 {
     /**
      * @param \PhpCollective\Toml\Ast\Document|null $document
@@ -14,9 +14,9 @@ final readonly class ParseResult
      * @param array<string, mixed>|null $value
      */
     public function __construct(
-        private ?Document $document,
-        private array $errors,
-        private ?array $value = null,
+        private readonly ?Document $document,
+        private readonly array $errors,
+        private readonly ?array $value = null,
     ) {
     }
 

--- a/src/Value/LocalDate.php
+++ b/src/Value/LocalDate.php
@@ -7,9 +7,9 @@ namespace PhpCollective\Toml\Value;
 use InvalidArgumentException;
 use PhpCollective\Toml\Support\TemporalValidator;
 
-final readonly class LocalDate implements TomlValue
+final class LocalDate implements TomlValue
 {
-    public function __construct(public string $value)
+    public function __construct(public readonly string $value)
     {
         if (!TemporalValidator::isValidLocalDate($value)) {
             throw new InvalidArgumentException("Invalid TOML local date: `{$value}`");

--- a/src/Value/LocalDateTime.php
+++ b/src/Value/LocalDateTime.php
@@ -7,9 +7,9 @@ namespace PhpCollective\Toml\Value;
 use InvalidArgumentException;
 use PhpCollective\Toml\Support\TemporalValidator;
 
-final readonly class LocalDateTime implements TomlValue
+final class LocalDateTime implements TomlValue
 {
-    public function __construct(public string $value)
+    public function __construct(public readonly string $value)
     {
         if (!TemporalValidator::isValidLocalDateTime($value)) {
             throw new InvalidArgumentException("Invalid TOML local datetime: `{$value}`");

--- a/src/Value/LocalTime.php
+++ b/src/Value/LocalTime.php
@@ -7,9 +7,9 @@ namespace PhpCollective\Toml\Value;
 use InvalidArgumentException;
 use PhpCollective\Toml\Support\TemporalValidator;
 
-final readonly class LocalTime implements TomlValue
+final class LocalTime implements TomlValue
 {
-    public function __construct(public string $value)
+    public function __construct(public readonly string $value)
     {
         if (!TemporalValidator::isValidLocalTime($value)) {
             throw new InvalidArgumentException("Invalid TOML local time: `{$value}`");


### PR DESCRIPTION
## Summary

Add PHP 8.1 support for the v1 release branch.

This lowers the runtime requirement to PHP 8.1, replaces PHP 8.2-only `readonly class` declarations with PHP 8.1-compatible readonly promoted properties, adds PHPUnit 10.5 for PHP 8.1 dependency resolution, and extends CI to cover PHP 8.1 on `v1` PRs.

## Verification

- composer validate --strict
- composer update --dry-run --no-install --prefer-dist --no-progress with `platform.php=8.1.0`
- composer cs-fix
- composer test
- composer stan
- composer cs-check
