### PR TITLE
Add opt-in encoder threshold options

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,12 @@ Toml::encodeFile('/path/to/config.toml', $array);
 // With options - e.g. omit nulls instead of throwing
 $toml = Toml::encode($array, new EncoderOptions(skipNulls: true));
 
+// Opt into multiline strings for long scalar strings
+$toml = Toml::encode($array, new EncoderOptions(multilineThreshold: 80));
+
+// Opt into inline tables for small flat nested arrays
+$toml = Toml::encode($array, new EncoderOptions(inlineTableThreshold: 3));
+
 // Strict TOML 1.0 output
 $toml = Toml::encode($array, new EncoderOptions(version: TomlVersion::V10));
 
@@ -129,6 +135,8 @@ $toml = Toml::encodeDocument(
 
 `DocumentFormattingMode::SourceAware` is lossless for unchanged parsed regions and uses local fallback rules for edited ones. See the [Compatibility](https://php-collective.github.io/toml/reference/compatibility) page for the exact editing contract.
 `skipNulls` lets `encode()` omit nulls instead of throwing.
+`multilineThreshold` (`?int`, default `null`) keeps current single-line strings when unset; when set, scalar strings longer than the threshold are encoded as multiline basic strings.
+`inlineTableThreshold` (`?int`, default `null`) keeps nested tables as table sections when unset; when set, flat nested arrays with at most that many keys are encoded inline, for example `point = { x = 1, y = 2 }`.
 
 ## Error Handling
 

--- a/docs/guide/encoding.md
+++ b/docs/guide/encoding.md
@@ -131,6 +131,44 @@ age = 30
 
 This also filters nulls from arrays and inline tables.
 
+### Multiline String Threshold
+
+`multilineThreshold` is an opt-in `?int` option. The default `null` keeps all scalar strings in the current single-line basic string form. When set, strings longer than the threshold use TOML multiline basic strings:
+
+```php
+$toml = Toml::encode([
+    'description' => 'a longer block of text',
+], new EncoderOptions(multilineThreshold: 10));
+```
+
+Output:
+
+```toml
+description = """
+a longer block of text"""
+```
+
+### Inline Table Threshold
+
+`inlineTableThreshold` is an opt-in `?int` option. The default `null` keeps nested associative arrays as table sections. When set, flat nested arrays with at most that many keys encode on the parent key line as inline tables:
+
+```php
+$toml = Toml::encode([
+    'point' => [
+        'x' => 1,
+        'y' => 2,
+    ],
+], new EncoderOptions(inlineTableThreshold: 3));
+```
+
+Output:
+
+```toml
+point = { x = 1, y = 2 }
+```
+
+Nested tables and arrays of tables still use table headers.
+
 ### Integer Grouping
 
 Add underscores to large integers for readability:

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -223,6 +223,8 @@ public function __construct(
     bool $dottedKeys = false,
     ArrayStyle $arrayStyle = ArrayStyle::Inline,
     int $arrayAutoThreshold = 3,
+    ?int $multilineThreshold = null,
+    ?int $inlineTableThreshold = null,
     string $indent = '    ',
 )
 ```
@@ -255,6 +257,8 @@ $toml = Toml::encode($data, EncoderOptions::diffFriendly());
 | `dottedKeys` | `bool` | `false` | Use dotted keys instead of table sections |
 | `arrayStyle` | `ArrayStyle` | `Inline` | Array formatting style (see below) |
 | `arrayAutoThreshold` | `int` | `3` | Item count threshold for `ArrayStyle::Auto` |
+| `multilineThreshold` | `?int` | `null` | Opt-in string length threshold for multiline basic strings in `encode()` |
+| `inlineTableThreshold` | `?int` | `null` | Opt-in key count threshold for small flat nested arrays to encode as inline tables |
 | `indent` | `string` | `'    '` | Indentation string for multiline arrays |
 
 ### ArrayStyle
@@ -312,6 +316,29 @@ $toml = Toml::encode(
 //   2,
 //   3,
 // ]
+```
+
+### Encoder Thresholds
+
+`multilineThreshold` is `?int` and defaults to `null`. When set, `encode()` emits scalar strings longer than the threshold as multiline basic strings.
+
+```php
+$toml = Toml::encode(
+    ['description' => 'a longer block of text'],
+    new EncoderOptions(multilineThreshold: 10),
+);
+// description = """
+// a longer block of text"""
+```
+
+`inlineTableThreshold` is `?int` and defaults to `null`. When set, `encode()` emits flat nested arrays with at most that many keys as inline tables; nested tables and arrays of tables still use table headers.
+
+```php
+$toml = Toml::encode(
+    ['point' => ['x' => 1, 'y' => 2]],
+    new EncoderOptions(inlineTableThreshold: 3),
+);
+// point = { x = 1, y = 2 }
 ```
 
 ### Integer Grouping

--- a/src/Encoder/Encoder.php
+++ b/src/Encoder/Encoder.php
@@ -87,7 +87,7 @@ final class Encoder
             if ($value === null && $this->options->skipNulls) {
                 continue;
             }
-            if (!is_array($value) || $this->isInlineArray($value)) {
+            if (!is_array($value) || $this->isInlineArray($value) || $this->shouldInlineTable($value)) {
                 $keyPath = $this->options->dottedKeys && $path !== []
                     ? $this->encodePath([...$path, (string)$key])
                     : $this->encodeKey((string)$key);
@@ -98,7 +98,7 @@ final class Encoder
         // Second pass: tables and array of tables
         foreach ($keys as $key) {
             $value = $data[$key];
-            if (is_array($value) && !$this->isInlineArray($value)) {
+            if (is_array($value) && !$this->isInlineArray($value) && !$this->shouldInlineTable($value)) {
                 $newPath = [...$path, (string)$key];
 
                 if ($this->isArrayOfTables($value)) {
@@ -148,6 +148,10 @@ final class Encoder
         }
 
         if (is_string($value)) {
+            if ($this->options->multilineThreshold !== null && mb_strlen($value) > $this->options->multilineThreshold) {
+                return $this->encodeMultilineBasicString($value);
+            }
+
             return $this->encodeString($value);
         }
 
@@ -1313,14 +1317,25 @@ final class Encoder
     private function encodeInlineTable(array $value): string
     {
         $items = [];
-        foreach ($value as $k => $v) {
+        $keys = array_keys($value);
+        if ($this->options->sortKeys) {
+            sort($keys);
+        }
+
+        foreach ($keys as $k) {
+            $v = $value[$k];
             if ($v === null && $this->options->skipNulls) {
                 continue;
             }
             $items[] = $this->encodeKey((string)$k) . ' = ' . $this->encodeValue($v);
         }
 
-        return '{ ' . implode(', ', $items) . ' }';
+        // Trailing commas in inline tables are only valid in TOML 1.1.
+        $trailing = $this->options->trailingComma
+            && $this->options->version === TomlVersion::V11
+            && $items !== [] ? ',' : '';
+
+        return '{ ' . implode(', ', $items) . $trailing . ' }';
     }
 
     private function encodeKey(string $key): string
@@ -1358,6 +1373,45 @@ final class Encoder
         }
         foreach ($value as $item) {
             if (!is_array($item) || array_is_list($item)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param array<mixed> $value
+     */
+    private function shouldInlineTable(array $value): bool
+    {
+        return $this->options->inlineTableThreshold !== null
+            && !array_is_list($value)
+            && count($value) <= $this->options->inlineTableThreshold
+            && $this->isInlineSafeTable($value);
+    }
+
+    /**
+     * @param array<mixed> $value
+     */
+    private function isInlineSafeTable(array $value): bool
+    {
+        foreach ($value as $item) {
+            if (is_array($item) && (!$this->isInlineArray($item) || !$this->isScalarList($item))) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param array<mixed> $value
+     */
+    private function isScalarList(array $value): bool
+    {
+        foreach ($value as $item) {
+            if (is_array($item)) {
                 return false;
             }
         }

--- a/src/Encoder/EncoderOptions.php
+++ b/src/Encoder/EncoderOptions.php
@@ -19,6 +19,8 @@ final readonly class EncoderOptions
         public bool $dottedKeys = false,
         public ArrayStyle $arrayStyle = ArrayStyle::Inline,
         public int $arrayAutoThreshold = 3,
+        public ?int $multilineThreshold = null,
+        public ?int $inlineTableThreshold = null,
         public string $indent = '    ',
     ) {
     }

--- a/tests/Encoder/EncoderThresholdsTest.php
+++ b/tests/Encoder/EncoderThresholdsTest.php
@@ -6,6 +6,7 @@ namespace PhpCollective\Toml\Test\Encoder;
 
 use PhpCollective\Toml\Encoder\EncoderOptions;
 use PhpCollective\Toml\Toml;
+use PhpCollective\Toml\TomlVersion;
 use PHPUnit\Framework\TestCase;
 
 final class EncoderThresholdsTest extends TestCase

--- a/tests/Encoder/EncoderThresholdsTest.php
+++ b/tests/Encoder/EncoderThresholdsTest.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCollective\Toml\Test\Encoder;
+
+use PhpCollective\Toml\Encoder\EncoderOptions;
+use PhpCollective\Toml\Toml;
+use PHPUnit\Framework\TestCase;
+
+final class EncoderThresholdsTest extends TestCase
+{
+    public function testMultilineThresholdNullKeepsLongStringSingleLine(): void
+    {
+        $toml = Toml::encode(
+            ['message' => 'this string is longer than ten characters'],
+            new EncoderOptions(multilineThreshold: null),
+        );
+
+        self::assertSame('message = "this string is longer than ten characters"', $toml);
+    }
+
+    public function testMultilineThresholdUsesMultilineStringOnlyAboveThreshold(): void
+    {
+        $toml = Toml::encode(
+            [
+                'long' => 'this string is longer than ten characters',
+                'short' => 'short',
+            ],
+            new EncoderOptions(multilineThreshold: 10),
+        );
+
+        self::assertSame(
+            "long = \"\"\"\nthis string is longer than ten characters\"\"\"\nshort = \"short\"",
+            $toml,
+        );
+    }
+
+    public function testInlineTableThresholdNullKeepsNestedTable(): void
+    {
+        $toml = Toml::encode(
+            [
+                'server' => [
+                    'host' => 'localhost',
+                    'port' => 8080,
+                ],
+            ],
+            new EncoderOptions(inlineTableThreshold: null),
+        );
+
+        self::assertSame("\n[server]\nhost = \"localhost\"\nport = 8080", $toml);
+    }
+
+    public function testInlineTableThresholdRendersSmallFlatTableInline(): void
+    {
+        $toml = Toml::encode(
+            [
+                'point' => [
+                    'a' => 1,
+                    'b' => 2,
+                ],
+            ],
+            new EncoderOptions(inlineTableThreshold: 3),
+        );
+
+        self::assertSame('point = { a = 1, b = 2 }', $toml);
+    }
+
+    public function testInlineTableThresholdKeepsLargeTableAsHeader(): void
+    {
+        $toml = Toml::encode(
+            [
+                'point' => [
+                    'a' => 1,
+                    'b' => 2,
+                    'c' => 3,
+                    'd' => 4,
+                ],
+            ],
+            new EncoderOptions(inlineTableThreshold: 3),
+        );
+
+        self::assertSame("\n[point]\na = 1\nb = 2\nc = 3\nd = 4", $toml);
+    }
+
+    public function testInlineTableThresholdKeepsTableContainingNestedTableAsHeader(): void
+    {
+        $toml = Toml::encode(
+            [
+                'server' => [
+                    'host' => 'localhost',
+                    'tls' => [
+                        'enabled' => true,
+                    ],
+                ],
+            ],
+            new EncoderOptions(inlineTableThreshold: 3),
+        );
+
+        self::assertSame("\n[server]\nhost = \"localhost\"\ntls = { enabled = true }", $toml);
+    }
+
+    public function testInlineTableThresholdHonorsSortKeysAndTrailingComma(): void
+    {
+        $toml = Toml::encode(
+            [
+                'point' => [
+                    'b' => 2,
+                    'a' => 1,
+                ],
+            ],
+            new EncoderOptions(
+                sortKeys: true,
+                trailingComma: true,
+                inlineTableThreshold: 3,
+            ),
+        );
+
+        self::assertSame('point = { a = 1, b = 2, }', $toml);
+    }
+
+    public function testMultilineThresholdNeverPromotesKeys(): void
+    {
+        // The threshold applies to string values only; quoted keys must stay
+        // single-line, since a multiline key would produce invalid TOML.
+        $toml = Toml::encode(
+            ['this is a very long quoted key indeed' => 'v'],
+            new EncoderOptions(multilineThreshold: 5),
+        );
+
+        self::assertStringNotContainsString('"""', $toml);
+        // Round-trips back to the same key/value.
+        self::assertSame(['this is a very long quoted key indeed' => 'v'], Toml::decode($toml));
+    }
+
+    public function testInlineTableOmitsTrailingCommaForToml10(): void
+    {
+        // Trailing commas in inline tables are invalid in TOML 1.0.
+        $toml = Toml::encode(
+            ['point' => ['a' => 1, 'b' => 2]],
+            new EncoderOptions(
+                version: TomlVersion::V10,
+                trailingComma: true,
+                inlineTableThreshold: 3,
+            ),
+        );
+
+        self::assertSame('point = { a = 1, b = 2 }', $toml);
+        self::assertSame(['point' => ['a' => 1, 'b' => 2]], Toml::decode($toml, TomlVersion::V10));
+    }
+}


### PR DESCRIPTION
## Summary

Adds two opt-in encoder formatting options from the 1.0 roadmap (#8). Both default to `null`, so encoder output is **byte-for-byte unchanged** unless a user sets them — safe to land before the stable tag.

## Options

### `multilineThreshold` (`?int`, default `null`)
When set, string **values** longer than the threshold (by `mb_strlen`) are emitted as multiline basic strings (`"""..."""`) instead of single-line.

```php
Toml::encode($data, new EncoderOptions(multilineThreshold: 80));
```

Applies to values only — keys are never promoted, since a multiline key would produce invalid TOML.

### `inlineTableThreshold` (`?int`, default `null`)
When set, a nested table with that many keys or fewer, whose values are all scalar/flat, renders as an inline table (`{ ... }`) instead of a `[header]` section.

```php
Toml::encode(['point' => ['x' => 1, 'y' => 2]], new EncoderOptions(inlineTableThreshold: 3));
// point = { x = 1, y = 2 }
```

Tables that contain nested tables or array-of-tables fall back to header form. Inline rendering honors `sortKeys` and `trailingComma`.

## Spec correctness

- Trailing commas inside inline tables are emitted **only for TOML 1.1** — TOML 1.0 forbids them, so under `version: V10` the comma is omitted.
- Long-string promotion never touches keys.

Both rules are covered by regression tests.

## Docs

README encoder-options table + entries, and `docs/guide/encoding.md` / `docs/reference/api.md` updated.
