### PR TITLE
Add opt-in string encoding styles

### DIFF
--- a/docs/guide/encoding.md
+++ b/docs/guide/encoding.md
@@ -347,6 +347,24 @@ message = "Hello\nWorld"
 path = "C:\\Users\\name"
 ```
 
+Literal or multiline string output can be enabled explicitly:
+
+```php
+use PhpCollective\Toml\Encoder\StringStyle;
+
+$toml = Toml::encode([
+    'path' => 'C:\Users\name',
+], new EncoderOptions(stringStyle: StringStyle::Literal));
+```
+
+Output:
+
+```toml
+path = 'C:\Users\name'
+```
+
+The default remains basic strings. Literal styles fall back to basic strings when a value cannot be represented safely in the requested style.
+
 ## Re-encoding from AST
 
 ```php

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -223,6 +223,7 @@ public function __construct(
     ArrayStyle $arrayStyle = ArrayStyle::Inline,
     int $arrayAutoThreshold = 3,
     string $indent = '    ',
+    StringStyle $stringStyle = StringStyle::Basic,
 )
 ```
 
@@ -248,13 +249,14 @@ $toml = Toml::encode($data, EncoderOptions::diffFriendly());
 | `newline` | `string` | `"\n"` | Newline sequence to use (`"\n"` or `"\r\n"`) |
 | `documentFormatting` | `DocumentFormattingMode` | `Normalized` | `Normalized` or `SourceAware` for `encodeDocument()` |
 | `skipNulls` | `bool` | `false` | Omit `null` values instead of throwing `EncodeException` |
-| `version` | `TomlVersion` | `V11` | TOML version for output rules |
+| `version` | `TomlVersion` | `V10` | TOML version for output rules |
 | `integerGrouping` | `bool` | `false` | Add underscores to large integers (e.g., `1_000_000`) |
 | `trailingComma` | `bool` | `false` | Add trailing commas to inline arrays |
 | `dottedKeys` | `bool` | `false` | Use dotted keys instead of table sections |
 | `arrayStyle` | `ArrayStyle` | `Inline` | Array formatting style (see below) |
 | `arrayAutoThreshold` | `int` | `3` | Item count threshold for `ArrayStyle::Auto` |
 | `indent` | `string` | `'    '` | Indentation string for multiline arrays |
+| `stringStyle` | `StringStyle` | `Basic` | String formatting style for plain PHP strings |
 
 ### ArrayStyle
 
@@ -332,6 +334,29 @@ $toml = Toml::encode(
 );
 // database.host = "localhost"
 // database.port = 5432
+```
+
+### StringStyle
+
+Controls how plain PHP strings are formatted during `encode()`.
+
+```php
+use PhpCollective\Toml\Encoder\StringStyle;
+```
+
+| Style | Description |
+|-------|-------------|
+| `StringStyle::Basic` | Basic double-quoted strings. This is the default and preserves current output behavior |
+| `StringStyle::Literal` | Single-quoted literal strings when representable; falls back to basic strings when needed |
+| `StringStyle::MultiLineBasic` | Multiline basic strings |
+| `StringStyle::MultiLineLiteral` | Multiline literal strings when representable; falls back to multiline basic strings when needed |
+
+```php
+$toml = Toml::encode(
+    ['path' => 'C:\Users\name'],
+    new EncoderOptions(stringStyle: StringStyle::Literal),
+);
+// path = 'C:\Users\name'
 ```
 
 ### TOML Version Modes

--- a/docs/reference/support-matrix.md
+++ b/docs/reference/support-matrix.md
@@ -68,7 +68,7 @@ The default parser/decoder behavior is TOML 1.1-compatible. The default encoder 
 
 | Feature | Status | Notes |
 |---------|--------|-------|
-| Strings | Supported | Encoded as basic strings |
+| Strings | Supported | Encoded as basic strings by default; literal and multiline styles are opt-in via `EncoderOptions` |
 | Integers | Supported | |
 | Floats | Supported | |
 | Booleans | Supported | |

--- a/src/Encoder/Encoder.php
+++ b/src/Encoder/Encoder.php
@@ -22,7 +22,7 @@ use PhpCollective\Toml\Ast\Value\LocalDate;
 use PhpCollective\Toml\Ast\Value\LocalDateTime;
 use PhpCollective\Toml\Ast\Value\LocalTime;
 use PhpCollective\Toml\Ast\Value\OffsetDateTime;
-use PhpCollective\Toml\Ast\Value\StringStyle;
+use PhpCollective\Toml\Ast\Value\StringStyle as AstStringStyle;
 use PhpCollective\Toml\Ast\Value\StringValue;
 use PhpCollective\Toml\Ast\Value\Value;
 use PhpCollective\Toml\Exception\EncodeException;
@@ -148,7 +148,7 @@ final class Encoder
         }
 
         if (is_string($value)) {
-            return $this->encodeString($value);
+            return $this->encodeStringValue($value);
         }
 
         if ($value instanceof DateTimeInterface) {
@@ -314,10 +314,10 @@ final class Encoder
         }
 
         return match ($value->style) {
-            StringStyle::Basic => $this->encodeString($value->value),
-            StringStyle::Literal => "'" . $value->value . "'",
-            StringStyle::MultiLineBasic => $this->encodeMultilineBasicString($value->value),
-            StringStyle::MultiLineLiteral => "'''\n" . $value->value . "'''",
+            AstStringStyle::Basic => $this->encodeString($value->value),
+            AstStringStyle::Literal => "'" . $value->value . "'",
+            AstStringStyle::MultiLineBasic => $this->encodeMultilineBasicString($value->value),
+            AstStringStyle::MultiLineLiteral => "'''\n" . $value->value . "'''",
         };
     }
 
@@ -1230,6 +1230,57 @@ final class Encoder
         );
 
         return '"' . $escaped . '"';
+    }
+
+    private function encodeStringValue(string $value): string
+    {
+        return match ($this->options->stringStyle) {
+            StringStyle::Basic => $this->encodeString($value),
+            StringStyle::Literal => $this->encodeLiteralString($value),
+            StringStyle::MultiLineBasic => $this->encodeMultilineBasicString($value),
+            StringStyle::MultiLineLiteral => $this->encodeMultilineLiteralString($value),
+        };
+    }
+
+    private function encodeLiteralString(string $value): string
+    {
+        if (!$this->canUseSingleLineLiteralString($value)) {
+            return $this->encodeString($value);
+        }
+
+        return "'" . $value . "'";
+    }
+
+    private function encodeMultilineLiteralString(string $value): string
+    {
+        if (!$this->canUseMultilineLiteralString($value)) {
+            return $this->encodeMultilineBasicString($value);
+        }
+
+        return "'''\n" . $value . "'''";
+    }
+
+    private function canUseSingleLineLiteralString(string $value): bool
+    {
+        return !str_contains($value, "'")
+            && !str_contains($value, "\n")
+            && !str_contains($value, "\r")
+            && !$this->containsDisallowedControlCharacter($value);
+    }
+
+    private function canUseMultilineLiteralString(string $value): bool
+    {
+        return !str_contains($value, "'''")
+            && !$this->containsDisallowedControlCharacter($value, allowNewline: true);
+    }
+
+    private function containsDisallowedControlCharacter(string $value, bool $allowNewline = false): bool
+    {
+        if ($allowNewline) {
+            return preg_match('/[\x00-\x08\x0B-\x1F\x7F]/', $value) === 1;
+        }
+
+        return preg_match('/[\x00-\x08\x0A-\x1F\x7F]/', $value) === 1;
     }
 
     /**

--- a/src/Encoder/EncoderOptions.php
+++ b/src/Encoder/EncoderOptions.php
@@ -20,6 +20,7 @@ final class EncoderOptions
         public readonly ArrayStyle $arrayStyle = ArrayStyle::Inline,
         public readonly int $arrayAutoThreshold = 3,
         public readonly string $indent = '    ',
+        public readonly StringStyle $stringStyle = StringStyle::Basic,
     ) {
     }
 

--- a/src/Encoder/StringStyle.php
+++ b/src/Encoder/StringStyle.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCollective\Toml\Encoder;
+
+enum StringStyle: string
+{
+    case Basic = 'basic';
+    case Literal = 'literal';
+    case MultiLineBasic = 'multiline_basic';
+    case MultiLineLiteral = 'multiline_literal';
+}

--- a/tests/Encoder/EncoderTest.php
+++ b/tests/Encoder/EncoderTest.php
@@ -9,6 +9,7 @@ use PhpCollective\Toml\Encoder\ArrayStyle;
 use PhpCollective\Toml\Encoder\DocumentFormattingMode;
 use PhpCollective\Toml\Encoder\Encoder;
 use PhpCollective\Toml\Encoder\EncoderOptions;
+use PhpCollective\Toml\Encoder\StringStyle;
 use PhpCollective\Toml\Exception\EncodeException;
 use PhpCollective\Toml\Toml;
 use PhpCollective\Toml\Value\LocalDate;
@@ -114,6 +115,63 @@ final class EncoderTest extends TestCase
 
         $this->assertStringContainsString('path = "line1\\nline2"', $result);
         $this->assertStringContainsString('quote = "say \\"hello\\""', $result);
+    }
+
+    public function testEncodeStringStyleLiteral(): void
+    {
+        $encoder = new Encoder(new EncoderOptions(stringStyle: StringStyle::Literal));
+
+        $result = $encoder->encode([
+            'path' => 'C:\Users\name',
+        ]);
+
+        $this->assertStringContainsString("path = 'C:\\Users\\name'", $result);
+    }
+
+    public function testEncodeStringStyleLiteralFallsBackToBasicWhenNeeded(): void
+    {
+        $encoder = new Encoder(new EncoderOptions(stringStyle: StringStyle::Literal));
+
+        $result = $encoder->encode([
+            'quote' => "it's fine",
+            'line' => "hello\nworld",
+        ]);
+
+        $this->assertStringContainsString('quote = "it\'s fine"', $result);
+        $this->assertStringContainsString('line = "hello\\nworld"', $result);
+    }
+
+    public function testEncodeStringStyleMultilineBasic(): void
+    {
+        $encoder = new Encoder(new EncoderOptions(stringStyle: StringStyle::MultiLineBasic));
+
+        $result = $encoder->encode([
+            'message' => "hello\nworld",
+        ]);
+
+        $this->assertStringContainsString("message = \"\"\"\nhello\nworld\"\"\"", $result);
+    }
+
+    public function testEncodeStringStyleMultilineLiteral(): void
+    {
+        $encoder = new Encoder(new EncoderOptions(stringStyle: StringStyle::MultiLineLiteral));
+
+        $result = $encoder->encode([
+            'message' => "hello\nworld",
+        ]);
+
+        $this->assertStringContainsString("message = '''\nhello\nworld'''", $result);
+    }
+
+    public function testEncodeStringStyleDoesNotChangeKeyStyle(): void
+    {
+        $encoder = new Encoder(new EncoderOptions(stringStyle: StringStyle::Literal));
+
+        $result = $encoder->encode([
+            'key with spaces' => 'value',
+        ]);
+
+        $this->assertStringContainsString('"key with spaces" = \'value\'', $result);
     }
 
     public function testEncodeDateTime(): void


### PR DESCRIPTION
## Summary

Add opt-in string encoding styles for the v1 release branch while keeping the default encoder output as basic double-quoted strings.

New `PhpCollective\Toml\Encoder\StringStyle` options:
- `Basic` - current default behavior
- `Literal` - single-quoted literal strings when representable, with basic-string fallback
- `MultiLineBasic` - multiline basic strings
- `MultiLineLiteral` - multiline literal strings when representable, with multiline-basic fallback

Quoted key encoding stays unchanged and continues to use basic strings where quoting is needed.

## Verification

- vendor/bin/phpunit tests/Encoder/EncoderTest.php
- composer cs-fix
- composer test
- composer stan
- composer cs-check
- composer validate --strict
