### PR TITLE
Add integer base output options to encoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,11 @@ $toml = Toml::encode($array, new EncoderOptions(inlineTableThreshold: 3));
 // Strict TOML 1.0 output
 $toml = Toml::encode($array, new EncoderOptions(version: TomlVersion::V10));
 
+// Emit integers in hexadecimal (or Octal / Binary)
+use PhpCollective\Toml\Ast\Value\IntegerBase;
+$toml = Toml::encode(['mask' => 255], new EncoderOptions(integerBase: IntegerBase::Hexadecimal));
+// mask = 0xFF
+
 // encodeDocument() is normalized by default
 $document = Toml::parse($tomlString, true);
 $toml = Toml::encodeDocument($document);
@@ -137,6 +142,7 @@ $toml = Toml::encodeDocument(
 `skipNulls` lets `encode()` omit nulls instead of throwing.
 `multilineThreshold` (`?int`, default `null`) keeps current single-line strings when unset; when set, scalar strings longer than the threshold are encoded as multiline basic strings.
 `inlineTableThreshold` (`?int`, default `null`) keeps nested tables as table sections when unset; when set, flat nested arrays with at most that many keys are encoded inline, for example `point = { x = 1, y = 2 }`.
+`integerBase` (`IntegerBase`, default `IntegerBase::Decimal`) controls the radix for integers produced by `encode()` (and normalized `encodeDocument()` output). `Hexadecimal`, `Octal`, and `Binary` emit `0x`/`0o`/`0b` literals. Since TOML allows a sign only on decimal integers, negative values always fall back to decimal. Source-aware document re-encoding preserves each integer's original source base regardless of this option.
 
 ## Error Handling
 
@@ -186,6 +192,8 @@ For explicit local temporal encoding, use:
 - `PhpCollective\Toml\Value\LocalDate`
 - `PhpCollective\Toml\Value\LocalTime`
 - `PhpCollective\Toml\Value\LocalDateTime`
+
+For per-value integer bases, wrap values in `PhpCollective\Toml\Value\TomlInteger` (e.g. `new TomlInteger(255, IntegerBase::Hexadecimal)` → `0xFF`).
 
 ## Comparison with Other PHP Libraries
 

--- a/docs/guide/encoding.md
+++ b/docs/guide/encoding.md
@@ -32,6 +32,7 @@ port = 5432
 |----------|-------------|
 | `string` | Basic string `"value"` |
 | `int` | Integer `42` |
+| `PhpCollective\Toml\Value\TomlInteger` | Integer in a chosen base, e.g. `0xFF` |
 | `float` | Float `3.14` |
 | `bool` | Boolean `true` / `false` |
 | `array` (list) | Array `[1, 2, 3]` |
@@ -183,6 +184,49 @@ Output:
 
 ```toml
 population = 1_000_000
+```
+
+### Integer Base
+
+`integerBase` controls the radix used for integers emitted by `encode()` (and normalized `encodeDocument()` output). The default is `IntegerBase::Decimal`; `Hexadecimal`, `Octal`, and `Binary` produce `0x`/`0o`/`0b` literals:
+
+```php
+use PhpCollective\Toml\Ast\Value\IntegerBase;
+
+$toml = Toml::encode([
+    'mask' => 255,
+    'mode' => 493,
+], new EncoderOptions(integerBase: IntegerBase::Hexadecimal));
+```
+
+Output:
+
+```toml
+mask = 0xFF
+mode = 0x1ED
+```
+
+::: tip
+TOML permits a sign only on decimal integers, so negative values always fall back to decimal regardless of `integerBase`. Source-aware document re-encoding preserves each integer's original source base instead of applying this option.
+:::
+
+`integerBase` applies one radix to every integer. For per-value control — e.g. a hexadecimal mask next to a decimal count — wrap individual values in `TomlInteger`:
+
+```php
+use PhpCollective\Toml\Ast\Value\IntegerBase;
+use PhpCollective\Toml\Value\TomlInteger;
+
+$toml = Toml::encode([
+    'mask' => new TomlInteger(255, IntegerBase::Hexadecimal),
+    'count' => 10,
+]);
+```
+
+Output:
+
+```toml
+mask = 0xFF
+count = 10
 ```
 
 ### Trailing Commas

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -219,6 +219,7 @@ public function __construct(
     bool $skipNulls = false,
     TomlVersion $version = TomlVersion::V11,
     bool $integerGrouping = false,
+    IntegerBase $integerBase = IntegerBase::Decimal,
     bool $trailingComma = false,
     bool $dottedKeys = false,
     ArrayStyle $arrayStyle = ArrayStyle::Inline,
@@ -253,6 +254,7 @@ $toml = Toml::encode($data, EncoderOptions::diffFriendly());
 | `skipNulls` | `bool` | `false` | Omit `null` values instead of throwing `EncodeException` |
 | `version` | `TomlVersion` | `V11` | TOML version for output rules |
 | `integerGrouping` | `bool` | `false` | Add underscores to large integers (e.g., `1_000_000`) |
+| `integerBase` | `IntegerBase` | `Decimal` | Radix for integers in `encode()` output (`Hexadecimal`/`Octal`/`Binary` emit `0x`/`0o`/`0b`; negatives stay decimal) |
 | `trailingComma` | `bool` | `false` | Add trailing commas to inline arrays |
 | `dottedKeys` | `bool` | `false` | Use dotted keys instead of table sections |
 | `arrayStyle` | `ArrayStyle` | `Inline` | Array formatting style (see below) |

--- a/src/Encoder/Encoder.php
+++ b/src/Encoder/Encoder.php
@@ -31,6 +31,7 @@ use PhpCollective\Toml\Support\TemporalValidator;
 use PhpCollective\Toml\TomlVersion;
 use PhpCollective\Toml\Value\LocalDateTime as ValueLocalDateTime;
 use PhpCollective\Toml\Value\LocalTime as ValueLocalTime;
+use PhpCollective\Toml\Value\TomlInteger;
 use PhpCollective\Toml\Value\TomlValue;
 
 final class Encoder
@@ -1234,6 +1235,13 @@ final class Encoder
 
     private function encodeInteger(int $value): string
     {
+        // Digit grouping is decimal-only, so non-decimal bases emit the bare literal.
+        // Negatives are left to the decimal path below: TOML allows a sign only on
+        // decimal integers, and this keeps grouping working for negative values.
+        if ($this->options->integerBase !== IntegerBase::Decimal && $value >= 0) {
+            return (new TomlInteger($value, $this->options->integerBase))->toTomlLiteral();
+        }
+
         if (!$this->options->integerGrouping) {
             return (string)$value;
         }

--- a/src/Encoder/EncoderOptions.php
+++ b/src/Encoder/EncoderOptions.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace PhpCollective\Toml\Encoder;
 
+use PhpCollective\Toml\Ast\Value\IntegerBase;
 use PhpCollective\Toml\TomlVersion;
 
 final readonly class EncoderOptions
@@ -15,6 +16,7 @@ final readonly class EncoderOptions
         public bool $skipNulls = false,
         public TomlVersion $version = TomlVersion::V11,
         public bool $integerGrouping = false,
+        public IntegerBase $integerBase = IntegerBase::Decimal,
         public bool $trailingComma = false,
         public bool $dottedKeys = false,
         public ArrayStyle $arrayStyle = ArrayStyle::Inline,

--- a/src/Value/TomlInteger.php
+++ b/src/Value/TomlInteger.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCollective\Toml\Value;
+
+use PhpCollective\Toml\Ast\Value\IntegerBase;
+
+final readonly class TomlInteger implements TomlValue
+{
+    public function __construct(
+        public int $value,
+        public IntegerBase $base = IntegerBase::Decimal,
+    ) {
+    }
+
+    public function toTomlLiteral(): string
+    {
+        // TOML permits a sign only on decimal integers; hex/octal/binary literals
+        // are unsigned, so negative values fall back to decimal output.
+        if ($this->base === IntegerBase::Decimal || $this->value < 0) {
+            return (string)$this->value;
+        }
+
+        return match ($this->base) {
+            IntegerBase::Hexadecimal => '0x' . strtoupper(dechex($this->value)),
+            IntegerBase::Octal => '0o' . decoct($this->value),
+            default => '0b' . decbin($this->value),
+        };
+    }
+}

--- a/tests/Encoder/EncoderTest.php
+++ b/tests/Encoder/EncoderTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpCollective\Toml\Test\Encoder;
 
 use DateTimeImmutable;
+use PhpCollective\Toml\Ast\Value\IntegerBase;
 use PhpCollective\Toml\Encoder\ArrayStyle;
 use PhpCollective\Toml\Encoder\DocumentFormattingMode;
 use PhpCollective\Toml\Encoder\Encoder;
@@ -14,6 +15,7 @@ use PhpCollective\Toml\Toml;
 use PhpCollective\Toml\Value\LocalDate;
 use PhpCollective\Toml\Value\LocalDateTime;
 use PhpCollective\Toml\Value\LocalTime;
+use PhpCollective\Toml\Value\TomlInteger;
 use PHPUnit\Framework\TestCase;
 
 final class EncoderTest extends TestCase
@@ -351,6 +353,122 @@ final class EncoderTest extends TestCase
         ]);
 
         $this->assertStringContainsString('large = 1000000', $result);
+    }
+
+    public function testEncodeIntegerBaseHexadecimal(): void
+    {
+        $encoder = new Encoder(new EncoderOptions(integerBase: IntegerBase::Hexadecimal));
+
+        $result = $encoder->encode([
+            'zero' => 0,
+            'mask' => 255,
+            'color' => 16711935,
+        ]);
+
+        $this->assertStringContainsString('zero = 0x0', $result);
+        $this->assertStringContainsString('mask = 0xFF', $result);
+        $this->assertStringContainsString('color = 0xFF00FF', $result);
+    }
+
+    public function testEncodeIntegerBaseOctal(): void
+    {
+        $encoder = new Encoder(new EncoderOptions(integerBase: IntegerBase::Octal));
+
+        $result = $encoder->encode([
+            'perms' => 493,
+        ]);
+
+        $this->assertStringContainsString('perms = 0o755', $result);
+    }
+
+    public function testEncodeIntegerBaseBinary(): void
+    {
+        $encoder = new Encoder(new EncoderOptions(integerBase: IntegerBase::Binary));
+
+        $result = $encoder->encode([
+            'flags' => 10,
+        ]);
+
+        $this->assertStringContainsString('flags = 0b1010', $result);
+    }
+
+    public function testEncodeIntegerBaseFallsBackToDecimalForNegativeValues(): void
+    {
+        // TOML hex/octal/binary literals are unsigned; negatives stay decimal so the
+        // output remains valid TOML.
+        $encoder = new Encoder(new EncoderOptions(integerBase: IntegerBase::Hexadecimal));
+
+        $result = $encoder->encode([
+            'negative' => -255,
+        ]);
+
+        $this->assertStringContainsString('negative = -255', $result);
+        $this->assertSame(-255, Toml::decode($result)['negative']);
+    }
+
+    public function testEncodeIntegerBaseDefaultsToDecimal(): void
+    {
+        $encoder = new Encoder(new EncoderOptions());
+
+        $result = $encoder->encode([
+            'value' => 255,
+        ]);
+
+        $this->assertStringContainsString('value = 255', $result);
+    }
+
+    public function testEncodeIntegerBaseRoundTripsToSameValue(): void
+    {
+        $encoder = new Encoder(new EncoderOptions(integerBase: IntegerBase::Hexadecimal));
+
+        $toml = $encoder->encode([
+            'mask' => 255,
+        ]);
+
+        $this->assertSame(255, Toml::decode($toml)['mask']);
+    }
+
+    public function testEncodeIntegerBaseDoesNotAffectSourceAwareDocumentBase(): void
+    {
+        // integerBase governs the array-encode path; source-aware document
+        // re-encoding preserves each integer's original source base instead.
+        $document = Toml::parse('mask = 0xFF' . "\n", true);
+
+        $toml = Toml::encodeDocument(
+            $document,
+            new EncoderOptions(
+                documentFormatting: DocumentFormattingMode::SourceAware,
+                integerBase: IntegerBase::Octal,
+            ),
+        );
+
+        $this->assertStringContainsString('0xFF', $toml);
+        $this->assertStringNotContainsString('0o', $toml);
+    }
+
+    public function testEncodeMixedIntegerBasesViaTomlIntegerValueObject(): void
+    {
+        // TomlInteger lets a plain array carry per-value bases, unlike the global
+        // integerBase option which applies one radix to every integer.
+        $encoder = new Encoder(new EncoderOptions());
+
+        $result = $encoder->encode([
+            'mask' => new TomlInteger(255, IntegerBase::Hexadecimal),
+            'mode' => new TomlInteger(493, IntegerBase::Octal),
+            'flags' => new TomlInteger(10, IntegerBase::Binary),
+            'count' => 10,
+        ]);
+
+        $this->assertStringContainsString('mask = 0xFF', $result);
+        $this->assertStringContainsString('mode = 0o755', $result);
+        $this->assertStringContainsString('flags = 0b1010', $result);
+        $this->assertStringContainsString('count = 10', $result);
+
+        $decoded = Toml::decode($result);
+        $this->assertSame(255, $decoded['mask']);
+        $this->assertSame(493, $decoded['mode']);
+        $this->assertSame(10, $decoded['flags']);
+        $this->assertSame(10, $decoded['count']);
     }
 
     public function testEncodeTrailingComma(): void

--- a/tests/Value/TomlIntegerTest.php
+++ b/tests/Value/TomlIntegerTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCollective\Toml\Test\Value;
+
+use PhpCollective\Toml\Ast\Value\IntegerBase;
+use PhpCollective\Toml\Value\TomlInteger;
+use PHPUnit\Framework\TestCase;
+
+final class TomlIntegerTest extends TestCase
+{
+    public function testDefaultsToDecimalLiteral(): void
+    {
+        $this->assertSame('255', (new TomlInteger(255))->toTomlLiteral());
+    }
+
+    public function testHexadecimalLiteral(): void
+    {
+        $this->assertSame('0xFF', (new TomlInteger(255, IntegerBase::Hexadecimal))->toTomlLiteral());
+        $this->assertSame('0x0', (new TomlInteger(0, IntegerBase::Hexadecimal))->toTomlLiteral());
+    }
+
+    public function testOctalLiteral(): void
+    {
+        $this->assertSame('0o755', (new TomlInteger(493, IntegerBase::Octal))->toTomlLiteral());
+    }
+
+    public function testBinaryLiteral(): void
+    {
+        $this->assertSame('0b1010', (new TomlInteger(10, IntegerBase::Binary))->toTomlLiteral());
+    }
+
+    public function testNegativeValueFallsBackToDecimal(): void
+    {
+        // TOML hex/octal/binary literals are unsigned; negatives stay decimal.
+        $this->assertSame('-255', (new TomlInteger(-255, IntegerBase::Hexadecimal))->toTomlLiteral());
+    }
+}


### PR DESCRIPTION
## Summary

Adds opt-in non-decimal integer output to the encoder. A PHP `int` carries no radix, so encoding to TOML always normalized integers to decimal. Two complementary options now cover the gap:

- **`EncoderOptions::$integerBase`** — applies one radix to every integer produced by `encode()` (and normalized `encodeDocument()` output). `Hexadecimal` / `Octal` / `Binary` emit `0x` / `0o` / `0b` literals.
- **`TomlInteger` value object** — carries a per-value base, so a single array can mix bases:

```php
use PhpCollective\Toml\Ast\Value\IntegerBase;
use PhpCollective\Toml\Value\TomlInteger;

Toml::encode(['mask' => 255], new EncoderOptions(integerBase: IntegerBase::Hexadecimal));
// mask = 0xFF

Toml::encode([
    'mask'  => new TomlInteger(255, IntegerBase::Hexadecimal),
    'count' => 10,
]);
// mask = 0xFF
// count = 10
```

## Behavior notes

- TOML allows a sign only on decimal integers, so negative values always fall back to decimal output regardless of the chosen base.
- Source-aware document re-encoding is unaffected — it preserves each integer's original source base via the AST, including mixed-base documents. `integerBase` only governs the array-encode (and normalized) path.
- Base-literal formatting lives in one place (`TomlInteger::toTomlLiteral()`); the encoder delegates to it.

## Docs

README, the encoding guide, and the API reference are updated (new option, the `TomlInteger` input type, and the negative/source-aware caveats).

## Compatibility

`integerBase` is inserted next to `integerGrouping` for readability rather than appended at the end, which shifts positions of later constructor parameters. The library is pre-1.0 and every call site uses named arguments, so this is a deliberate trade-off; positional callers, if any, would need to switch to named arguments.
