### PR TITLE
Encode stdClass as a table (enables empty-table output)

### DIFF
--- a/docs/reference/limitations.md
+++ b/docs/reference/limitations.md
@@ -129,7 +129,7 @@ This also works for nulls in arrays and inline tables.
 
 ## Object Encoding
 
-Only `DateTimeInterface` objects and explicit TOML value wrappers are supported for direct object encoding. Other objects must be converted to arrays:
+`DateTimeInterface` objects, explicit TOML value wrappers, and `stdClass` are supported for direct object encoding. `stdClass` is treated as a table (see [Empty Tables](#empty-tables)). Any other object throws `EncodeException` and must be converted to an array first:
 
 ```php
 // This throws EncodeException
@@ -148,7 +148,20 @@ Toml::encode(['settings' => []]);
 // Output: settings = []   (not an empty [settings] table)
 ```
 
-**Workaround:** Add at least one key, or build an `encodeDocument()` AST when an explicit empty table header is required. A pure decode/encode round trip of an empty table is therefore not byte-preserving in normalized mode.
+**Workaround:** Use `stdClass` to force table output. An empty `stdClass` becomes an empty table header, and a populated one is encoded just like an associative array:
+
+```php
+Toml::encode(['settings' => new stdClass()]);
+// Output: [settings]
+
+$server = new stdClass();
+$server->host = 'localhost';
+Toml::encode(['server' => $server]);
+// Output: [server]
+//         host = "localhost"
+```
+
+Inside an inline context (an array element, or under `inlineTableThreshold`), a `stdClass` is emitted as an inline table, so an empty one becomes `{}`. A pure decode/encode round trip of an empty table is still not byte-preserving in normalized mode, because decoding yields a plain empty array; use `DocumentFormattingMode::SourceAware` to preserve the original `[]` vs `{}` form.
 
 ## Recursive Structures
 

--- a/docs/reference/support-matrix.md
+++ b/docs/reference/support-matrix.md
@@ -77,7 +77,8 @@ The default API behavior is TOML 1.1-compatible. Strict TOML 1.0 parsing/decodin
 | Array of tables | Supported | |
 | Quoted keys when needed | Supported | |
 | `DateTimeInterface` | Partial | Encoded as offset datetime; zero fractional seconds are omitted and a `+00:00` offset is emitted as `Z` |
-| Empty tables | Not Yet | An empty PHP array encodes as `[]`; PHP cannot distinguish it from an empty table |
+| `stdClass` as table | Supported | A `stdClass` encodes as a table (`[key]`), or an inline table in inline contexts; an empty one emits an empty table |
+| Empty tables | Partial | An empty PHP array encodes as `[]`; use an empty `stdClass` to emit an empty `[table]` |
 | `PhpCollective\Toml\Value\LocalDate` | Supported | Encoded as local date literal |
 | `PhpCollective\Toml\Value\LocalTime` | Supported | Encoded as local time literal; strict TOML 1.0 mode normalizes missing seconds |
 | `PhpCollective\Toml\Value\LocalDateTime` | Supported | Encoded as local datetime literal; strict TOML 1.0 mode normalizes missing seconds |

--- a/src/Encoder/Encoder.php
+++ b/src/Encoder/Encoder.php
@@ -33,6 +33,7 @@ use PhpCollective\Toml\Value\LocalDateTime as ValueLocalDateTime;
 use PhpCollective\Toml\Value\LocalTime as ValueLocalTime;
 use PhpCollective\Toml\Value\TomlInteger;
 use PhpCollective\Toml\Value\TomlValue;
+use stdClass;
 
 final class Encoder
 {
@@ -82,13 +83,13 @@ final class Encoder
             sort($keys);
         }
 
-        // First pass: scalar values
+        // First pass: scalar values and values emitted inline (incl. inline tables)
         foreach ($keys as $key) {
             $value = $data[$key];
             if ($value === null && $this->options->skipNulls) {
                 continue;
             }
-            if (!is_array($value) || $this->isInlineArray($value) || $this->shouldInlineTable($value)) {
+            if ($this->isInlineEmittedValue($value)) {
                 $keyPath = $this->options->dottedKeys && $path !== []
                     ? $this->encodePath([...$path, (string)$key])
                     : $this->encodeKey((string)$key);
@@ -99,24 +100,65 @@ final class Encoder
         // Second pass: tables and array of tables
         foreach ($keys as $key) {
             $value = $data[$key];
-            if (is_array($value) && !$this->isInlineArray($value) && !$this->shouldInlineTable($value)) {
-                $newPath = [...$path, (string)$key];
+            if ($value === null && $this->options->skipNulls) {
+                continue;
+            }
+            if ($this->isInlineEmittedValue($value)) {
+                continue;
+            }
 
-                if ($this->isArrayOfTables($value)) {
-                    foreach ($value as $item) {
-                        $lines[] = '';
-                        $lines[] = '[[' . $this->encodePath($newPath) . ']]';
-                        $this->encodeTable($item, $newPath, $lines);
-                    }
-                } elseif ($this->options->dottedKeys) {
-                    $this->encodeTable($value, $newPath, $lines);
-                } else {
+            $newPath = [...$path, (string)$key];
+
+            if (is_array($value) && $this->isArrayOfTables($value)) {
+                foreach ($value as $item) {
                     $lines[] = '';
-                    $lines[] = '[' . $this->encodePath($newPath) . ']';
-                    $this->encodeTable($value, $newPath, $lines);
+                    $lines[] = '[[' . $this->encodePath($newPath) . ']]';
+                    $this->encodeTable($item, $newPath, $lines);
                 }
+            } elseif ($this->options->dottedKeys) {
+                $table = $this->toTableArray($value);
+                if ($table === []) {
+                    // Dotted-key mode emits no `[table]` headers, so an empty table
+                    // (only reachable via an empty stdClass) is written inline.
+                    $lines[] = $this->encodePath($newPath) . ' = {}';
+                } else {
+                    $this->encodeTable($table, $newPath, $lines);
+                }
+            } else {
+                $lines[] = '';
+                $lines[] = '[' . $this->encodePath($newPath) . ']';
+                $this->encodeTable($this->toTableArray($value), $newPath, $lines);
             }
         }
+    }
+
+    /**
+     * Decides whether a value is emitted on the assignment line (`key = ...`) rather
+     * than as a `[table]` section. A `stdClass` always denotes a table, so it is only
+     * emitted inline when the inline-table threshold opts it in; an empty `stdClass`
+     * therefore becomes an empty `[table]` header.
+     */
+    private function isInlineEmittedValue(mixed $value): bool
+    {
+        if ($value instanceof stdClass) {
+            return $this->shouldInlineTable(get_object_vars($value));
+        }
+
+        if (!is_array($value)) {
+            return true;
+        }
+
+        return $this->isInlineArray($value) || $this->shouldInlineTable($value);
+    }
+
+    /**
+     * @param \stdClass|array<string, mixed> $value
+     *
+     * @return array<string, mixed>
+     */
+    private function toTableArray(stdClass|array $value): array
+    {
+        return $value instanceof stdClass ? get_object_vars($value) : $value;
     }
 
     private function encodeValue(mixed $value): string
@@ -177,6 +219,10 @@ final class Encoder
 
         if ($value instanceof TomlValue) {
             return $value->toTomlLiteral();
+        }
+
+        if ($value instanceof stdClass) {
+            return $this->encodeInlineTable(get_object_vars($value));
         }
 
         if (is_array($value)) {
@@ -1367,6 +1413,10 @@ final class Encoder
      */
     private function encodeInlineTable(array $value): string
     {
+        if ($value === []) {
+            return '{}';
+        }
+
         $items = [];
         $keys = array_keys($value);
         if ($this->options->sortKeys) {

--- a/tests/Encoder/EncoderTest.php
+++ b/tests/Encoder/EncoderTest.php
@@ -18,6 +18,7 @@ use PhpCollective\Toml\Value\LocalTime;
 use PhpCollective\Toml\Value\TomlInteger;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
+use stdClass;
 
 final class EncoderTest extends TestCase
 {
@@ -786,5 +787,87 @@ final class EncoderTest extends TestCase
         ]);
 
         $this->assertStringContainsString('x = 1987-07-05T17:45:00Z', $result);
+    }
+
+    public function testEncodeEmptyStdClassAsEmptyTable(): void
+    {
+        $encoder = new Encoder(new EncoderOptions());
+
+        $result = $encoder->encode(['settings' => new stdClass()]);
+
+        $this->assertSame('[settings]', trim($result));
+    }
+
+    public function testEncodeEmptyArrayStillEncodesAsArray(): void
+    {
+        // Backward compatible: an empty array is unchanged by stdClass table support.
+        $encoder = new Encoder(new EncoderOptions());
+
+        $result = $encoder->encode(['arr' => []]);
+
+        $this->assertSame('arr = []', trim($result));
+    }
+
+    public function testEncodeStdClassAsTableSection(): void
+    {
+        $encoder = new Encoder(new EncoderOptions());
+
+        $object = new stdClass();
+        $object->host = 'localhost';
+        $object->port = 8080;
+
+        $result = $encoder->encode(['server' => $object]);
+
+        $this->assertStringContainsString('[server]', $result);
+        $this->assertStringContainsString('host = "localhost"', $result);
+        $this->assertStringContainsString('port = 8080', $result);
+    }
+
+    public function testEncodeNestedEmptyStdClass(): void
+    {
+        $encoder = new Encoder(new EncoderOptions());
+
+        $outer = new stdClass();
+        $outer->inner = new stdClass();
+
+        $result = $encoder->encode(['a' => $outer]);
+
+        $this->assertStringContainsString('[a]', $result);
+        $this->assertStringContainsString('[a.inner]', $result);
+    }
+
+    public function testEncodeStdClassInsideArrayAsInlineTable(): void
+    {
+        $encoder = new Encoder(new EncoderOptions());
+
+        $populated = new stdClass();
+        $populated->x = 1;
+
+        $result = $encoder->encode(['list' => [$populated, new stdClass()]]);
+
+        $this->assertStringContainsString('list = [{ x = 1 }, {}]', $result);
+    }
+
+    public function testEncodeStdClassRespectsInlineTableThreshold(): void
+    {
+        $encoder = new Encoder(new EncoderOptions(inlineTableThreshold: 3));
+
+        $point = new stdClass();
+        $point->x = 1;
+        $point->y = 2;
+
+        $result = $encoder->encode(['p' => $point]);
+
+        $this->assertSame('p = { x = 1, y = 2 }', trim($result));
+    }
+
+    public function testEncodeEmptyStdClassWithDottedKeys(): void
+    {
+        // Dotted-key mode emits no [table] headers, so an empty table is written inline.
+        $encoder = new Encoder(new EncoderOptions(dottedKeys: true));
+
+        $result = $encoder->encode(['a' => (object)['b' => new stdClass()]]);
+
+        $this->assertSame('a.b = {}', trim($result));
     }
 }

--- a/tests/PublicApi/ContractsTest.php
+++ b/tests/PublicApi/ContractsTest.php
@@ -12,7 +12,6 @@ use PhpCollective\Toml\Exception\ParseException;
 use PhpCollective\Toml\Exception\TomlException;
 use PhpCollective\Toml\Toml;
 use PHPUnit\Framework\TestCase;
-use stdClass;
 
 final class ContractsTest extends TestCase
 {
@@ -54,15 +53,21 @@ final class ContractsTest extends TestCase
     {
         $this->expectException(EncodeException::class);
 
+        // stdClass is now supported (encoded as a table); an arbitrary object is not.
         Toml::encode([
-            'object' => new stdClass(),
+            'object' => new class {
+            },
         ]);
     }
 
     public function testEncodeExceptionExtendsTomlException(): void
     {
         try {
-            Toml::encode(['object' => new stdClass()]);
+            Toml::encode([
+
+                'object' => new class {
+                },
+            ]);
             $this->fail('Expected EncodeException was not thrown.');
         } catch (EncodeException $exception) {
             $this->assertInstanceOf(TomlException::class, $exception);


### PR DESCRIPTION
## Summary

Lets the encoder emit a TOML table from a `\stdClass`, which gives users a way to produce an **empty table** — something a plain PHP array cannot express, because `[]` is both an empty list and an empty map.

Follow-up to #32. Backward compatible: `stdClass` previously always threw `EncodeException`, so accepting it only adds behavior.

## Behavior

- Empty `stdClass` → empty table header `[key]` (or `key = {}` in `dottedKeys` mode, which emits no headers).
- Populated `stdClass` → encoded like an associative array (table section, or an inline table under `inlineTableThreshold` / inside an array element).
- Empty array stays `[]` — unchanged.
- Arbitrary non-`stdClass` objects still throw `EncodeException`.

```php
Toml::encode(['settings' => new stdClass()]);
// [settings]

$server = new stdClass();
$server->host = 'localhost';
Toml::encode(['server' => $server]);
// [server]
// host = "localhost"
```

## Why

This is the same escape hatch that `PetalBranch/toml` and `devium/toml` already offer (both map `stdClass` to a table); `yosymfony/toml` and `php-internal/toml` have none. Our source-aware `encodeDocument()` already round-trips `[]` vs `{}` exactly via the AST; this closes the gap on the plain `encode()` path.

## Docs

Updated the limitations and support-matrix references (object encoding, empty tables).
