### PR TITLE
ci: gate spec conformance with pinned toml-test corpus

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,11 @@ jobs:
       - name: Install dependencies
         run: composer update --prefer-dist --no-progress
 
+      # Pinned for reproducibility; bump the tag when adopting newer corpus tests.
+      # Without it, the conformance tests skip instead of gating spec compliance.
+      - name: Fetch toml-test corpus
+        run: git clone --depth 1 --branch v2.2.0 https://github.com/toml-lang/toml-test.git /tmp/toml-test
+
       - name: Run tests
         run: vendor/bin/phpunit
 

--- a/docs/reference/support-matrix.md
+++ b/docs/reference/support-matrix.md
@@ -117,21 +117,21 @@ The default API behavior is TOML 1.1-compatible. Strict TOML 1.0 parsing/decodin
 
 ## toml-test Compliance
 
-Tested against [toml-test](https://github.com/toml-lang/toml-test) v2.1.0:
+Tested against [toml-test](https://github.com/toml-lang/toml-test) v2.2.0:
 
 ### TOML 1.1
 
 | Test Type | Passed | Failed | Compliance |
 |-----------|--------|--------|------------|
-| Valid | 214 | 0 | 100% |
-| Invalid | 466 | 0 | 100% |
+| Valid | 213 | 0 | 100% |
+| Invalid | 467 | 0 | 100% |
 
 ### TOML 1.0
 
 | Test Type | Passed | Failed | Compliance |
 |-----------|--------|--------|------------|
-| Valid | 205 | 0 | 100% |
-| Invalid | 473 | 0 | 100% |
+| Valid | 204 | 0 | 100% |
+| Invalid | 474 | 0 | 100% |
 
 These results were measured against the library's `bin/toml-decoder` adapter for the `toml-test` tagged JSON format. TOML 1.1 results use the default adapter mode; TOML 1.0 results use `TOML_VERSION=1.0` so the decoder runs in strict TOML 1.0 mode.
 
@@ -139,7 +139,7 @@ Strict TOML 1.0 mode closes the previously documented invalid-case gaps for synt
 
 A leading UTF-8 BOM (`U+FEFF`) at the very start of a document is accepted and skipped, matching the `toml-test` corpus and common parsers.
 
-A matching `bin/toml-encoder` adapter implements the `toml-test` encoder protocol (tagged JSON to TOML). It is exercised by `TomlTestEncoderTest`, which encodes each fixture and decodes the result back to confirm valid, semantically equivalent output. Both adapters are skipped automatically when the `toml-test` corpus is not present locally.
+A matching `bin/toml-encoder` adapter implements the `toml-test` encoder protocol (tagged JSON to TOML). It is exercised by `TomlTestEncoderTest`, which encodes each fixture and decodes the result back to confirm valid, semantically equivalent output. Both adapters are skipped automatically when the `toml-test` corpus is not present locally; CI clones the pinned corpus version so these checks gate every pull request.
 
 ## Recommended Use
 


### PR DESCRIPTION
## Summary

The conformance tests (`TomlTestDecoderTest`, `TomlTestEncoderTest`) skip when the `toml-test` corpus is not present, so CI ran them as no-ops — spec compliance was only ever measured locally. This clones the corpus (pinned to **v2.2.0**) in the `tests` job so the full suite gates every pull request.

`actions/checkout` cannot target a path outside the workspace, so a pinned shallow `git clone` into `/tmp/toml-test` is used (the path the tests look for).

## Why pinned

Pinning to a tag keeps CI reproducible and prevents a green build from turning red when upstream adds corpus tests we don't yet handle. Bump the tag deliberately when adopting newer tests.

## Measured at v2.2.0 (now gated)

| Suite | Valid | Invalid |
|-------|-------|---------|
| TOML 1.1 | 213 / 213 | 467 / 467 |
| TOML 1.0 | 204 / 204 | 474 / 474 |

100% both directions, both spec versions. Support-matrix compliance numbers refreshed from the stale v2.1.0 figures to these.
