### PR TITLE
Add stable error codes, lint bin/, and document file/diagnostics APIs

### DIFF
--- a/bin/toml-decoder
+++ b/bin/toml-decoder
@@ -25,9 +25,8 @@ final class JsonObject
     /**
      * @param array<array-key, mixed> $entries
      */
-    public function __construct(
-        public array $entries = [],
-    ) {
+    public function __construct(public array $entries = [])
+    {
     }
 }
 
@@ -52,7 +51,7 @@ try {
 }
 
 /**
- * @return JsonObject
+ * @return \JsonObject
  */
 function convertDocument(Document $doc): JsonObject
 {
@@ -165,6 +164,7 @@ function formatOffset(DateTimeInterface $dt): string
     if ($offset === '+00:00') {
         return 'Z';
     }
+
     return $offset;
 }
 
@@ -250,8 +250,10 @@ function tagValue(string $type, string $value): JsonObject
 }
 
 /**
- * @param JsonObject|array<mixed> $obj
+ * @param \JsonObject|array<mixed> $obj
  * @param array<string> $path
+ * @param mixed $value
+ * @throws \RuntimeException
  */
 function setNestedValue(JsonObject|array &$obj, array $path, mixed $value): void
 {
@@ -295,7 +297,7 @@ function setNestedValue(JsonObject|array &$obj, array $path, mixed $value): void
 }
 
 /**
- * @param JsonObject|array<mixed> $obj
+ * @param \JsonObject|array<mixed> $obj
  * @param array<string> $path
  */
 function getNestedValue(JsonObject|array $obj, array $path): mixed
@@ -326,7 +328,7 @@ function getNestedValue(JsonObject|array $obj, array $path): mixed
 }
 
 /**
- * @param JsonObject|array<mixed> $value
+ * @param \JsonObject|array<mixed> $value
  */
 function isListNode(JsonObject|array $value): bool
 {

--- a/bin/toml-encoder
+++ b/bin/toml-encoder
@@ -11,6 +11,7 @@
 
 require __DIR__ . '/../vendor/autoload.php';
 
+use PhpCollective\Toml\Encoder\EncoderOptions;
 use PhpCollective\Toml\Toml;
 use PhpCollective\Toml\TomlVersion;
 use PhpCollective\Toml\Value\LocalDate;
@@ -30,7 +31,7 @@ try {
         throw new RuntimeException('Top-level TOML value must be a table');
     }
 
-    echo Toml::encode($data, new PhpCollective\Toml\Encoder\EncoderOptions(version: $version));
+    echo Toml::encode($data, new EncoderOptions(version: $version));
 } catch (Throwable $e) {
     fwrite(STDERR, $e->getMessage() . "\n");
     exit(1);
@@ -38,6 +39,8 @@ try {
 
 /**
  * Converts a toml-test tagged JSON node into the PHP value the encoder expects.
+ *
+ * @throws \RuntimeException
  */
 function convertNode(mixed $node): mixed
 {

--- a/docs/guide/error-handling.md
+++ b/docs/guide/error-handling.md
@@ -64,10 +64,32 @@ In the current implementation, `getDocument()` is still available for invalid in
 Each error contains:
 
 ```php
-$error->message;     // string - Error description
+$error->message;     // string - Error description (human-readable, not a stable contract)
 $error->span;        // Span - Position information
 $error->hint;        // string|null - Suggestion for fixing
+$error->code;        // ParseErrorCode - Stable, machine-readable classification
 ```
+
+### Stable Error Codes
+
+Each error carries a `ParseErrorCode` enum value. Switch on it instead of matching the message, which may change between releases:
+
+```php
+use PhpCollective\Toml\Parser\ParseErrorCode;
+
+foreach ($result->getErrors() as $error) {
+    match ($error->code) {
+        ParseErrorCode::DuplicateKey,
+        ParseErrorCode::DuplicateTable => reportDuplicate($error),
+        ParseErrorCode::IntegerOutOfRange => reportOverflow($error),
+        default => reportGeneric($error),
+    };
+}
+```
+
+The thrown `ParseException` exposes the same value as `$exception->errorCode` (named to avoid colliding with the base `Exception::$code`).
+
+The codes group into syntax (`ExpectedKey`, `ExpectedValue`, `ExpectedToken`, `UnexpectedToken`, `UnterminatedStatement`, `UnsupportedVersion`), lexical (`InvalidToken`, `InvalidEncoding`, `UnterminatedString`, `InvalidNumber`, `IntegerOutOfRange`, `InvalidDateTime`), and semantic (`DuplicateKey`, `DuplicateTable`, `KeyRedefinition`, `TableRedefinition`, `ArrayTableConflict`, `ExtendStaticArray`, `ExtendInlineTable`, `DottedKeyConflict`) categories, plus a generic `SyntaxError` fallback.
 
 ### Span Information
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -117,6 +117,26 @@ $toml = Toml::encodeDocument(
 
 `encodeDocument()` defaults to normalized output. With `DocumentFormattingMode::SourceAware`, it can preserve parsed comments, blank lines, lexical styles, and collection-local layout for trivia-preserving ASTs.
 
+### encodeFile()
+
+```php
+public static function encodeFile(string $path, array $data, ?EncoderOptions $options = null): void
+```
+
+Encodes a PHP array to TOML and writes it to `$path`. Throws `EncodeException` on an encoding error or if the file cannot be written.
+
+```php
+Toml::encodeFile('/path/to/config.toml', ['server' => ['port' => 8080]]);
+```
+
+### encodeDocumentFile()
+
+```php
+public static function encodeDocumentFile(string $path, Document $document, ?EncoderOptions $options = null): void
+```
+
+Encodes an AST Document to TOML and writes it to `$path`. Throws `EncodeException` on an encoding error or if the file cannot be written.
+
 ---
 
 ## ParseResult
@@ -164,10 +184,13 @@ Represents a parse error with position information.
 ### Properties
 
 ```php
-public readonly string $message;    // Error description
-public readonly Span $span;         // Position information
-public readonly ?string $hint;      // Optional fix suggestion
+public readonly string $message;        // Error description
+public readonly Span $span;             // Position information
+public readonly ?string $hint;          // Optional fix suggestion
+public readonly ParseErrorCode $code;   // Stable, machine-readable classification
 ```
+
+The `code` is a `ParseErrorCode` enum (string-backed). Prefer switching on it over matching the human-readable `message`, which is not a stable contract. See [Error Handling](../guide/error-handling).
 
 ### format()
 

--- a/docs/reference/support-matrix.md
+++ b/docs/reference/support-matrix.md
@@ -141,6 +141,15 @@ A leading UTF-8 BOM (`U+FEFF`) at the very start of a document is accepted and s
 
 A matching `bin/toml-encoder` adapter implements the `toml-test` encoder protocol (tagged JSON to TOML). It is exercised by `TomlTestEncoderTest`, which encodes each fixture and decodes the result back to confirm valid, semantically equivalent output. Both adapters are skipped automatically when the `toml-test` corpus is not present locally; CI clones the pinned corpus version so these checks gate every pull request.
 
+### Encoder round-trip (v2.2.0 valid corpus)
+
+| Version | Byte-equivalent | Notes |
+|---------|-----------------|-------|
+| TOML 1.1 | 194 / 214 | |
+| TOML 1.0 | 185 / 205 | |
+
+Every difference in the remaining cases is an artifact of the toml-test harness, not invalid output: the tagged JSON represents an empty table as `{}`, which PHP's `json_decode` turns into an empty array (so the encoder emits `[]`, see [Empty Tables](limitations#empty-tables)), and a NUL byte cannot be a PHP object key. The TOML the encoder produces for those fixtures is valid and semantically equal; it simply does not byte-match. No remaining case is a real encoder defect.
+
 ## Recommended Use
 
 This library is well suited for:

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -3,6 +3,9 @@
     <arg value="nps"/>
     <arg name="cache" value=".phpcs.cache"/>
 
+    <file>bin/toml-decoder</file>
+    <file>bin/toml-encoder</file>
+    <file>bin/toml-validate</file>
     <file>src/</file>
     <file>tests/</file>
 
@@ -12,5 +15,11 @@
 
     <rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInDeclaration"/>
     <rule ref="SlevomatCodingStandard.Functions.RequireTrailingCommaInClosureUse"/>
+
+    <!-- bin/ entry-point scripts are extensionless executables and may define a
+         script-local helper class without a namespace. -->
+    <rule ref="PSR1.Classes.ClassDeclaration.MissingNamespace">
+        <exclude-pattern>bin/*</exclude-pattern>
+    </rule>
 
 </ruleset>

--- a/src/Exception/ParseException.php
+++ b/src/Exception/ParseException.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace PhpCollective\Toml\Exception;
 
 use PhpCollective\Toml\Lexer\Span;
+use PhpCollective\Toml\Parser\ParseErrorCode;
 
 class ParseException extends TomlException
 {
@@ -12,6 +13,7 @@ class ParseException extends TomlException
         string $message,
         public readonly ?Span $span = null,
         public readonly ?string $hint = null,
+        public readonly ?ParseErrorCode $errorCode = null,
     ) {
         parent::__construct($message);
     }

--- a/src/Parser/ParseError.php
+++ b/src/Parser/ParseError.php
@@ -8,11 +8,19 @@ use PhpCollective\Toml\Lexer\Span;
 
 final readonly class ParseError
 {
+    /**
+     * Stable, machine-readable error classification. Derived from the message when
+     * not provided explicitly.
+     */
+    public ParseErrorCode $code;
+
     public function __construct(
         public string $message,
         public Span $span,
         public ?string $hint = null,
+        ?ParseErrorCode $code = null,
     ) {
+        $this->code = $code ?? ParseErrorCode::fromMessage($message);
     }
 
     public function format(string $input): string

--- a/src/Parser/ParseErrorCode.php
+++ b/src/Parser/ParseErrorCode.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCollective\Toml\Parser;
+
+/**
+ * Stable, machine-readable classification for parse and semantic errors.
+ *
+ * The string values are part of the public contract: tooling may switch on them
+ * instead of matching against human-readable messages, which are not stable.
+ */
+enum ParseErrorCode: string
+{
+    // Generic fallback when no more specific code applies.
+    case SyntaxError = 'syntax_error';
+
+    // Syntax (parser).
+    case ExpectedKey = 'expected_key';
+    case ExpectedValue = 'expected_value';
+    case ExpectedToken = 'expected_token';
+    case UnexpectedToken = 'unexpected_token';
+    case UnterminatedStatement = 'unterminated_statement';
+    case UnsupportedVersion = 'unsupported_version';
+
+    // Lexical (token level).
+    case InvalidToken = 'invalid_token';
+    case InvalidEncoding = 'invalid_encoding';
+    case UnterminatedString = 'unterminated_string';
+    case InvalidNumber = 'invalid_number';
+    case IntegerOutOfRange = 'integer_out_of_range';
+    case InvalidDateTime = 'invalid_datetime';
+
+    // Semantic (normalizer).
+    case DuplicateKey = 'duplicate_key';
+    case DuplicateTable = 'duplicate_table';
+    case KeyRedefinition = 'key_redefinition';
+    case TableRedefinition = 'table_redefinition';
+    case ArrayTableConflict = 'array_table_conflict';
+    case ExtendStaticArray = 'extend_static_array';
+    case ExtendInlineTable = 'extend_inline_table';
+    case DottedKeyConflict = 'dotted_key_conflict';
+
+    /**
+     * Classifies an error from its message. Keyed on the stable message stems
+     * produced by the parser and normalizer; pinned by tests. Lexer "Invalid
+     * token" errors are coded via {@see self::fromInvalidLexeme()} instead,
+     * because that message alone does not carry the specific cause.
+     */
+    public static function fromMessage(string $message): self
+    {
+        return match (true) {
+            str_starts_with($message, 'Duplicate key') => self::DuplicateKey,
+            str_starts_with($message, 'Duplicate table') => self::DuplicateTable,
+            str_starts_with($message, 'Cannot redefine array table') => self::ArrayTableConflict,
+            str_starts_with($message, 'Cannot redefine key') => self::KeyRedefinition,
+            str_starts_with($message, 'Cannot redefine table') => self::TableRedefinition,
+            str_starts_with($message, 'Cannot extend inline table') => self::ExtendInlineTable,
+            str_starts_with($message, 'Cannot extend static array') => self::ExtendStaticArray,
+            str_starts_with($message, 'Cannot extend values in static array') => self::ExtendStaticArray,
+            str_starts_with($message, 'Cannot add keys to explicitly defined table') => self::DottedKeyConflict,
+            str_starts_with($message, 'Cannot define table') => self::DottedKeyConflict,
+            str_starts_with($message, 'Invalid UTF-8') => self::InvalidEncoding,
+            str_starts_with($message, 'Invalid token') => self::InvalidToken,
+            str_starts_with($message, 'Expected key') => self::ExpectedKey,
+            str_starts_with($message, 'Expected value') => self::ExpectedValue,
+            str_starts_with($message, 'Expected =') => self::ExpectedToken,
+            str_starts_with($message, 'Unexpected token') => self::UnexpectedToken,
+            str_contains($message, 'TOML 1.0') || str_contains($message, 'TOML 1.1') => self::UnsupportedVersion,
+            str_contains($message, 'terminated by newline') || str_starts_with($message, 'Expected newline') => self::UnterminatedStatement,
+            str_starts_with($message, 'Expected') => self::ExpectedToken,
+            default => self::SyntaxError,
+        };
+    }
+
+    /**
+     * Classifies a lexer "Invalid token" error from the rejected lexeme. The lexer
+     * only marks an otherwise-valid integer as invalid on out-of-range overflow,
+     * so a bare integer lexeme maps to {@see self::IntegerOutOfRange}.
+     */
+    public static function fromInvalidLexeme(string $lexeme): self
+    {
+        if ($lexeme !== '' && ($lexeme[0] === '"' || $lexeme[0] === "'")) {
+            // A closed quote means the string terminated but its content was invalid
+            // (e.g. a bad escape); only an unclosed quote is genuinely unterminated.
+            $terminated = strlen($lexeme) >= 2 && $lexeme[-1] === $lexeme[0];
+
+            return $terminated ? self::InvalidToken : self::UnterminatedString;
+        }
+
+        return match (true) {
+            // Only a syntactically valid decimal integer (no leading zero, no
+            // doubled/edge underscores) that the lexer still rejected is an overflow;
+            // malformed numbers like `+01` fall through to InvalidNumber.
+            preg_match('/^[+-]?[1-9](_?[0-9])*$/', $lexeme) === 1 => self::IntegerOutOfRange,
+            preg_match('/^\d{4}-\d{2}-\d{2}/', $lexeme) === 1 || preg_match('/^\d{2}:\d{2}/', $lexeme) === 1 => self::InvalidDateTime,
+            preg_match('/^[+-]?(0[xobXOB])?[0-9a-fA-F._eE+-]+$/', $lexeme) === 1 => self::InvalidNumber,
+            default => self::InvalidToken,
+        };
+    }
+}

--- a/src/Parser/Parser.php
+++ b/src/Parser/Parser.php
@@ -148,7 +148,7 @@ final class Parser
                 $this->advance();
             } elseif ($token->is(TokenType::Invalid)) {
                 $hint = $this->getInvalidTokenHint($token->value);
-                $this->error("Invalid token: `{$token->value}`", $token->span, $hint);
+                $this->error("Invalid token: `{$token->value}`", $token->span, $hint, ParseErrorCode::fromInvalidLexeme($token->value));
                 $this->synchronize();
             } else {
                 $hint = $this->getUnexpectedTokenHint($token);
@@ -223,7 +223,7 @@ final class Parser
             $token = $this->current();
             if ($token->is(TokenType::Invalid)) {
                 $hint = $this->getInvalidTokenHint($token->value);
-                $this->error("Invalid token: `{$token->value}`", $token->span, $hint);
+                $this->error("Invalid token: `{$token->value}`", $token->span, $hint, ParseErrorCode::fromInvalidLexeme($token->value));
             } else {
                 $hint = $this->getExpectedValueHint($token);
                 $this->error('Expected value', $token->span, $hint);
@@ -274,7 +274,7 @@ final class Parser
             $token = $this->current();
             if ($token->is(TokenType::Invalid)) {
                 $hint = $this->getInvalidTokenHint($token->value);
-                $this->error("Invalid token: `{$token->value}`", $token->span, $hint);
+                $this->error("Invalid token: `{$token->value}`", $token->span, $hint, ParseErrorCode::fromInvalidLexeme($token->value));
             } else {
                 $hint = $this->getExpectedValueHint($token);
                 $this->error('Expected value', $token->span, $hint);
@@ -1251,9 +1251,9 @@ final class Parser
         return $buffer;
     }
 
-    private function error(string $message, Span $span, ?string $hint = null): void
+    private function error(string $message, Span $span, ?string $hint = null, ?ParseErrorCode $code = null): void
     {
-        $this->errors[] = new ParseError($message, $span, $hint);
+        $this->errors[] = new ParseError($message, $span, $hint, $code);
     }
 
     /**

--- a/src/Toml.php
+++ b/src/Toml.php
@@ -32,7 +32,7 @@ final class Toml
         if ($errors !== []) {
             $error = $errors[0];
 
-            throw new ParseException($error->message, $error->span, $error->hint);
+            throw new ParseException($error->message, $error->span, $error->hint, $error->code);
         }
 
         return $value;

--- a/tests/Parser/ErrorRecoveryTest.php
+++ b/tests/Parser/ErrorRecoveryTest.php
@@ -222,4 +222,30 @@ TOML;
         // Should have parsed elements before and after the invalid one
         $this->assertGreaterThanOrEqual(2, count($arr->items));
     }
+
+    public function testRecoveryCollectsMultipleErrorsAcrossLines(): void
+    {
+        // Lines 1, 2 and 4 are broken; line 3 is valid and must still parse.
+        $result = Toml::tryParse("a = \nb = @\nc = 1\nd = ]");
+
+        $errors = $result->getErrors();
+        $this->assertCount(3, $errors);
+        $this->assertSame([1, 2, 4], array_map(static fn ($e) => $e->span->line, $errors));
+
+        $doc = $result->getDocument();
+        $this->assertNotNull($doc);
+        $valid = array_filter($doc->items, static fn ($item) => $item instanceof KeyValue && $item->key->parts === ['c']);
+        $this->assertCount(1, $valid);
+    }
+
+    public function testRecoveryContinuesAcrossTableHeaders(): void
+    {
+        // An error in one table must not stop collection in a later table.
+        $result = Toml::tryParse("[t]\nx = \ny = 1\n[u]\nz = @");
+
+        $errors = $result->getErrors();
+        $this->assertCount(2, $errors);
+        $this->assertSame(2, $errors[0]->span->line);
+        $this->assertSame(5, $errors[1]->span->line);
+    }
 }

--- a/tests/Parser/ParseErrorCodeTest.php
+++ b/tests/Parser/ParseErrorCodeTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpCollective\Toml\Test\Parser;
+
+use PhpCollective\Toml\Exception\ParseException;
+use PhpCollective\Toml\Parser\ParseErrorCode;
+use PhpCollective\Toml\Toml;
+use PhpCollective\Toml\TomlVersion;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+final class ParseErrorCodeTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{string, \PhpCollective\Toml\Parser\ParseErrorCode}>
+     */
+    public static function codeProvider(): iterable
+    {
+        yield 'integer overflow' => ['x = 9223372036854775808', ParseErrorCode::IntegerOutOfRange];
+        yield 'unterminated string' => ['x = "abc', ParseErrorCode::UnterminatedString];
+        yield 'invalid escape' => ['x = "\q"', ParseErrorCode::InvalidToken];
+        yield 'invalid datetime' => ['x = 2024-13-45', ParseErrorCode::InvalidDateTime];
+        yield 'expected value' => ['x =', ParseErrorCode::ExpectedValue];
+        yield 'missing equals' => ['x 1', ParseErrorCode::ExpectedToken];
+        yield 'unexpected token' => ['} = 1', ParseErrorCode::UnexpectedToken];
+        yield 'duplicate key' => ["a = 1\na = 2", ParseErrorCode::DuplicateKey];
+        yield 'duplicate table' => ["[t]\n[t]", ParseErrorCode::DuplicateTable];
+        yield 'key redefinition' => ["a = 1\n[a]\nb = 2", ParseErrorCode::KeyRedefinition];
+        yield 'extend inline table' => ["a = {x = 1}\na.y = 2", ParseErrorCode::ExtendInlineTable];
+    }
+
+    #[DataProvider('codeProvider')]
+    public function testParseAssignsStableErrorCode(string $toml, ParseErrorCode $expected): void
+    {
+        $result = Toml::tryParse($toml);
+        $errors = $result->getErrors();
+
+        $this->assertNotEmpty($errors);
+        $this->assertSame($expected, $errors[0]->code, $errors[0]->message);
+    }
+
+    public function testDecodeExceptionCarriesErrorCode(): void
+    {
+        try {
+            Toml::decode("a = 1\na = 2");
+            $this->fail('Expected ParseException');
+        } catch (ParseException $exception) {
+            $this->assertSame(ParseErrorCode::DuplicateKey, $exception->errorCode);
+        }
+    }
+
+    public function testStrictVersionErrorIsCoded(): void
+    {
+        $result = Toml::tryParse('point = { x = 1, }', TomlVersion::V10);
+
+        $this->assertNotEmpty($result->getErrors());
+        $this->assertSame(ParseErrorCode::UnsupportedVersion, $result->getErrors()[0]->code);
+    }
+
+    public function testFromMessageFallsBackToSyntaxError(): void
+    {
+        $this->assertSame(ParseErrorCode::SyntaxError, ParseErrorCode::fromMessage('something unmapped'));
+    }
+
+    public function testFromInvalidLexemeDistinguishesUnterminatedFromClosed(): void
+    {
+        $this->assertSame(ParseErrorCode::UnterminatedString, ParseErrorCode::fromInvalidLexeme('"abc'));
+        $this->assertSame(ParseErrorCode::InvalidToken, ParseErrorCode::fromInvalidLexeme('"\q"'));
+        $this->assertSame(ParseErrorCode::IntegerOutOfRange, ParseErrorCode::fromInvalidLexeme('9223372036854775808'));
+    }
+
+    public function testMalformedDecimalIsNotReportedAsOverflow(): void
+    {
+        // Leading-zero and bad-underscore integers are syntax errors, not overflow.
+        $this->assertSame(ParseErrorCode::InvalidNumber, ParseErrorCode::fromInvalidLexeme('+01'));
+        $this->assertSame(ParseErrorCode::InvalidNumber, ParseErrorCode::fromInvalidLexeme('-01'));
+        $this->assertSame(ParseErrorCode::InvalidNumber, ParseErrorCode::fromInvalidLexeme('+1__2'));
+    }
+}


### PR DESCRIPTION
## Summary

A batch of diagnostics, convenience, and tooling improvements (gaps 1-5 from the library review).

## Stable error codes (gap 4)

Adds a `ParseErrorCode` string-backed enum exposed on every error:

```php
foreach (Toml::tryParse($input)->getErrors() as $error) {
    if ($error->code === ParseErrorCode::DuplicateKey) { /* ... */ }
}
```

`ParseException` exposes the same value as `$exception->errorCode` (named to avoid colliding with the base `Exception::$code`). Codes are derived from the stable parser/normalizer message stems, and for lexer "Invalid token" errors from the rejected lexeme. Covers syntax, lexical, and semantic categories so tooling can switch on a stable contract instead of matching human-readable messages.

## Lint the harness scripts (gap 3)

`bin/` was previously unchecked. Adds the entry-point scripts to PHPCS (and fixes the style drift this surfaced). PHPStan stays on `src/` + `tests/`; the JSON-juggling toml-test adapters are not library code and level-8 retrofitting them is poor value.

## Docs (gaps 1, 2)

- Document `encodeFile()` / `encodeDocumentFile()` (the write counterparts to `decodeFile()`, already present in code) in the API reference.
- Document the error-code workflow in the error-handling guide.
- Publish encoder round-trip numbers in the support matrix (194/214 on TOML 1.1, 185/205 on 1.0 against toml-test v2.2.0), noting the remaining differences are empty-table/NUL harness artifacts, not defects.

## Recovery regression tests (gap 5)

Multi-error recovery already works well, so this locks the behavior with tests for collection across lines and table headers rather than rewriting the resync logic.
