### PR TITLE
Improve in-collection error recovery for missing separators

### DIFF
--- a/src/Parser/Parser.php
+++ b/src/Parser/Parser.php
@@ -666,13 +666,24 @@ final class Parser
             $items[] = $value;
 
             $trailingTrivia = $this->preserveTrivia ? $this->collectCollectionTrivia() : [];
+            $gapHadNewline = $this->triviaContainsNewline($trailingTrivia);
             if (!$this->preserveTrivia) {
-                $this->skipTriviaInCollection();
+                $gapHadNewline = $this->skipTriviaInCollection();
             }
 
             if (!$this->check(TokenType::RightBracket)) {
                 if (!$this->match(TokenType::Comma)) {
-                    break;
+                    // A newline before the next token suggests an unterminated array,
+                    // so hand control back to the document parser instead of swallowing
+                    // following top-level keys. A same-line gap is a missing comma:
+                    // report once and recover in place rather than cascading.
+                    if ($gapHadNewline) {
+                        break;
+                    }
+
+                    $this->error('Expected , or ] in array', $this->current()->span);
+
+                    continue;
                 }
 
                 if ($this->preserveTrivia) {
@@ -751,14 +762,25 @@ final class Parser
             }
 
             $trailingTrivia = $this->preserveTrivia ? $this->collectCollectionTrivia() : [];
-            $hasInlineTableLayoutNewline = $this->triviaContainsNewline($trailingTrivia) || $hasInlineTableLayoutNewline;
+            $gapHadNewline = $this->triviaContainsNewline($trailingTrivia);
             if (!$this->preserveTrivia) {
-                $hasInlineTableLayoutNewline = $this->skipTriviaInCollection() || $hasInlineTableLayoutNewline;
+                $gapHadNewline = $this->skipTriviaInCollection() || $gapHadNewline;
             }
+            $hasInlineTableLayoutNewline = $gapHadNewline || $hasInlineTableLayoutNewline;
 
             if (!$this->check(TokenType::RightBrace)) {
                 if (!$this->match(TokenType::Comma)) {
-                    break;
+                    // A newline before the next token suggests an unterminated table,
+                    // so hand control back to the document parser. A same-line gap is
+                    // a missing comma: report once and recover in place rather than
+                    // leaking the remainder and cascading into misleading errors.
+                    if ($gapHadNewline) {
+                        break;
+                    }
+
+                    $this->error('Expected , or } in inline table', $this->current()->span);
+
+                    continue;
                 }
                 if ($this->preserveTrivia) {
                     $kv->setTrailingTrivia($trailingTrivia);

--- a/tests/Parser/ErrorRecoveryTest.php
+++ b/tests/Parser/ErrorRecoveryTest.php
@@ -248,4 +248,111 @@ TOML;
         $this->assertSame(2, $errors[0]->span->line);
         $this->assertSame(5, $errors[1]->span->line);
     }
+
+    public function testMissingCommaInInlineTableReportsOnceAndRecovers(): void
+    {
+        // A single missing separator must not cascade or leak the `}` to the
+        // document parser; both key-values still parse.
+        $result = Toml::tryParse('t = { x = 1 y = 2 }');
+
+        $errors = $result->getErrors();
+        $this->assertCount(1, $errors);
+        $this->assertSame('Expected , or } in inline table', $errors[0]->message);
+
+        $doc = $result->getDocument();
+        $this->assertNotNull($doc);
+        $this->assertInstanceOf(KeyValue::class, $doc->items[0]);
+        $inlineTable = $doc->items[0]->value;
+        $this->assertInstanceOf(InlineTable::class, $inlineTable);
+        $this->assertCount(2, $inlineTable->items);
+    }
+
+    public function testMultipleMissingCommasInInlineTableRecoverEveryItem(): void
+    {
+        $result = Toml::tryParse('t = { x = 1 y = 2 z = 3 }');
+
+        $this->assertCount(2, $result->getErrors());
+
+        $doc = $result->getDocument();
+        $this->assertNotNull($doc);
+        $this->assertInstanceOf(KeyValue::class, $doc->items[0]);
+        $inlineTable = $doc->items[0]->value;
+        $this->assertInstanceOf(InlineTable::class, $inlineTable);
+        $this->assertCount(3, $inlineTable->items);
+    }
+
+    public function testMissingCommaInArrayReportsAndRecovers(): void
+    {
+        $result = Toml::tryParse('a = [1 2 3]');
+
+        // One separator error per gap, no document-level cascade.
+        $this->assertCount(2, $result->getErrors());
+        foreach ($result->getErrors() as $error) {
+            $this->assertSame('Expected , or ] in array', $error->message);
+        }
+
+        $doc = $result->getDocument();
+        $this->assertNotNull($doc);
+        $this->assertInstanceOf(KeyValue::class, $doc->items[0]);
+        $array = $doc->items[0]->value;
+        $this->assertInstanceOf(ArrayValue::class, $array);
+        $this->assertCount(3, $array->items);
+    }
+
+    public function testUnterminatedArrayDoesNotSwallowFollowingKey(): void
+    {
+        // The array is missing its `]`; `b` is a new top-level key on the next line
+        // and must not be absorbed into the array recovery.
+        $result = Toml::tryParse("a = [1\nb = 2");
+
+        $doc = $result->getDocument();
+        $this->assertNotNull($doc);
+        $keys = array_map(
+            static fn ($item) => $item instanceof KeyValue ? implode('.', $item->key->parts) : null,
+            $doc->items,
+        );
+        $this->assertContains('b', $keys);
+    }
+
+    public function testUnterminatedInlineTableDoesNotSwallowFollowingKey(): void
+    {
+        $result = Toml::tryParse("a = { x = 1\nb = 2");
+
+        $doc = $result->getDocument();
+        $this->assertNotNull($doc);
+        $keys = array_map(
+            static fn ($item) => $item instanceof KeyValue ? implode('.', $item->key->parts) : null,
+            $doc->items,
+        );
+        $this->assertContains('b', $keys);
+    }
+
+    public function testUnterminatedArrayDoesNotSwallowValueLikeKey(): void
+    {
+        // `2` is a value token but here begins a top-level `2 = 3` key; the newline
+        // boundary must keep it out of the array.
+        $result = Toml::tryParse("a = [1\n2 = 3");
+
+        $doc = $result->getDocument();
+        $this->assertNotNull($doc);
+        $keys = array_map(
+            static fn ($item) => $item instanceof KeyValue ? implode('.', $item->key->parts) : null,
+            $doc->items,
+        );
+        $this->assertContains('2', $keys);
+    }
+
+    public function testSameLineMissingCommaRecoversValueKeywordsAndMultilineStrings(): void
+    {
+        // No newline in the gaps, so these are missing-comma typos: report and recover
+        // without dropping the top-level key.
+        $result = Toml::tryParse('a = [1 nan "x"]');
+
+        $doc = $result->getDocument();
+        $this->assertNotNull($doc);
+        $this->assertInstanceOf(KeyValue::class, $doc->items[0]);
+        $array = $doc->items[0]->value;
+        $this->assertInstanceOf(ArrayValue::class, $array);
+        $this->assertCount(3, $array->items);
+    }
 }


### PR DESCRIPTION
## Summary

Improves parser error recovery for a missing separator inside an inline table or array.

Previously a missing comma broke out of the collection and leaked the rest to the document parser, cascading into several misleading errors — a single missing comma in `t = { x = 1 y = 2 }` produced four.

## Behavior

- **Same-line missing separator** → report one error and recover in place, so every element is still collected:
  - `t = { x = 1 y = 2 }` → 1 error, both key-values parsed.
  - `a = [1 2 3]` → one error per gap, all three elements parsed.
- **Newline before the next token** → treat the collection as likely unterminated and hand control back to the document parser, so following top-level keys are never swallowed:
  - `a = [1\nb = 2` and `a = { x = 1\nb = 2` keep `b` as a top-level key.
  - `a = [1\n2 = 3` keeps the value-like key `2` (the newline boundary, not a token whitelist, makes the call).

Valid input — single-line and multiline arrays and inline tables — is unaffected; only already-malformed input changes, and it now produces fewer, clearer errors with the surrounding structure preserved.

## Notes

Two `codex review` rounds hardened this against swallowing following statements. A residual extra terminator error on genuinely unterminated collections is pre-existing (the newline path takes the same break-and-hand-back route the parser always used) and leaves all data intact, so it is out of scope here.
